### PR TITLE
Fix optional TableRequirement field

### DIFF
--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -171,6 +171,22 @@ impl TableMetadata {
             .ok_or_else(|| Error::InvalidFormat("partition spec".to_string()))
     }
 
+    /// Lookup snapshot by id.
+    #[inline]
+    pub fn snapshot_by_id(&self, snapshot_id: i64) -> Option<&Snapshot> {
+        self.snapshots.get(&snapshot_id)
+    }
+    
+    /// Get the snapshot for a reference
+    /// Returns an option if the `ref_name` is not found
+    #[inline]
+    pub fn snapshot_for_ref(&self, ref_name: &str) -> Option<&Snapshot> {
+        self.refs.get(ref_name).map(|r| {
+            self.snapshot_by_id(r.snapshot_id)
+                .unwrap_or_else(|| panic!("Snapshot id of ref {} doesn't exist", ref_name))
+        })
+    }
+    
     /// Get partition fields
     pub fn current_partition_fields(
         &self,

--- a/iceberg-rust/src/catalog/commit.rs
+++ b/iceberg-rust/src/catalog/commit.rs
@@ -154,7 +154,7 @@ pub enum TableRequirement {
         /// Name of ref
         r#ref: String,
         /// Snapshot id
-        snapshot_id: i64,
+        snapshot_id: Option<i64>,
     },
     /// The table's last assigned column id must match the requirement's `last-assigned-field-id`
     AssertLastAssignedFieldId {
@@ -258,11 +258,12 @@ pub fn check_table_requirements(
         // Assert create has to be check in another place
         TableRequirement::AssertCreate => true,
         TableRequirement::AssertTableUuid { uuid } => metadata.table_uuid == *uuid,
-        TableRequirement::AssertRefSnapshotId { r#ref, snapshot_id } => metadata
-            .refs
-            .get(r#ref)
-            .map(|id| id.snapshot_id == *snapshot_id)
-            .unwrap_or(false),
+        TableRequirement::AssertRefSnapshotId { r#ref, snapshot_id } => {
+            match (snapshot_id, metadata.snapshot_for_ref(r#ref)) {
+                (Some(snapshot_id), Some(snapshot_ref)) => snapshot_ref.snapshot_id() == snapshot_id,
+                _ => true,
+            }
+        }
         TableRequirement::AssertLastAssignedFieldId {
             last_assigned_field_id,
         } => metadata.last_column_id == *last_assigned_field_id,

--- a/iceberg-rust/src/catalog/commit.rs
+++ b/iceberg-rust/src/catalog/commit.rs
@@ -336,19 +336,6 @@ pub fn apply_table_updates(
                 });
                 metadata.last_updated_ms = *snapshot.timestamp_ms();
                 metadata.last_sequence_number = *snapshot.sequence_number();
-
-                metadata.refs
-                    .entry("main".to_string())
-                    .and_modify(|s| {
-                        s.snapshot_id = *snapshot.snapshot_id();
-                    })
-                    .or_insert_with(|| {
-                        SnapshotReference {
-                            snapshot_id: *snapshot.snapshot_id(),
-                            retention: SnapshotRetention::default(),
-                        }
-                    });
-                
                 metadata.snapshots.insert(*snapshot.snapshot_id(), snapshot);
             }
             TableUpdate::SetSnapshotRef {

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -353,7 +353,7 @@ impl Operation {
                 Ok((
                     old_snapshot.map(|x| TableRequirement::AssertRefSnapshotId {
                         r#ref: branch.clone().unwrap_or("main".to_owned()),
-                        snapshot_id: *x.snapshot_id(),
+                        snapshot_id: Some(*x.snapshot_id()),
                     }),
                     vec![
                         TableUpdate::AddSnapshot { snapshot },
@@ -514,7 +514,7 @@ impl Operation {
                 Ok((
                     old_snapshot.map(|x| TableRequirement::AssertRefSnapshotId {
                         r#ref: branch.clone().unwrap_or("main".to_owned()),
-                        snapshot_id: *x.snapshot_id(),
+                        snapshot_id: Some(*x.snapshot_id()),
                     }),
                     vec![
                         TableUpdate::RemoveSnapshots {
@@ -543,7 +543,7 @@ impl Operation {
                     .get(&key)
                     .map(|x| TableRequirement::AssertRefSnapshotId {
                         r#ref: key.clone(),
-                        snapshot_id: x.snapshot_id,
+                        snapshot_id: Some(x.snapshot_id),
                     }),
                 vec![TableUpdate::SetSnapshotRef {
                     ref_name: key,


### PR DESCRIPTION
The fields should be optional
https://github.com/apache/iceberg-rust/blob/main/crates/iceberg/src/catalog/mod.rs#L321

  /// The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`;
  /// if `snapshot-id` is `null` or missing, the ref must not already exist