### PR TITLE
Fix decimal serde

### DIFF
--- a/iceberg-rust-spec/src/spec/types.rs
+++ b/iceberg-rust-spec/src/spec/types.rs
@@ -114,7 +114,8 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    let (precision, scale) = s
+    let filtered = s.replace(" ", "");
+    let (precision, scale) = filtered
         .trim_start_matches(r"decimal(")
         .trim_end_matches(')')
         .split_once(',')


### PR DESCRIPTION
decimal(15,2)
decimal(15, 2) - initial issue was here.  When we trying to get metadata json we use AvroReader that converts Decimal128{p, s} to "decimal(15, 2)". JaunKaul decimal serialiser cannot parse spaces.

