### PR TITLE
Append operation summary

### DIFF
--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -1,6 +1,10 @@
 use std::cmp::Ordering;
+use std::collections::HashMap;
 
-use iceberg_rust_spec::{manifest::ManifestEntry, manifest_list::ManifestListEntry};
+use iceberg_rust_spec::{
+    manifest::Content, manifest::DataFile, manifest::ManifestEntry,
+    manifest_list::ManifestListEntry,
+};
 use smallvec::SmallVec;
 
 use crate::{
@@ -188,4 +192,24 @@ pub(crate) fn select_manifest_unpartitioned(
             file_count_all_entries,
         })
         .ok_or(Error::NotFound("Manifest for insert".to_owned()))
+}
+
+pub(crate) fn append_summary(files: &[DataFile]) -> Option<HashMap<String, String>> {
+    if files.is_empty() {
+        return None;
+    }
+
+    let (mut added_data_files, mut added_records, mut added_files_size) = (0usize, 0i64, 0i64);
+
+    for file in files.iter().filter(|f| *f.content() == Content::Data) {
+        added_data_files += 1;
+        added_records += file.record_count();
+        added_files_size += file.file_size_in_bytes();
+    }
+
+    Some(HashMap::from([
+        ("added-files-size".into(), added_files_size.to_string()),
+        ("added-records".into(), added_records.to_string()),
+        ("added-data-files".into(), added_data_files.to_string()),
+    ]))
 }

--- a/iceberg-rust/src/table/transaction/mod.rs
+++ b/iceberg-rust/src/table/transaction/mod.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use iceberg_rust_spec::spec::{manifest::DataFile, schema::Schema, snapshot::SnapshotReference};
 
+use crate::table::transaction::append::append_summary;
 use crate::{catalog::commit::CommitTable, error::Error, table::Table};
 
 use self::operation::Operation;
@@ -118,14 +119,13 @@ impl<'table> TableTransaction<'table> {
     ///     .await?;
     /// ```
     pub fn append_data(mut self, files: Vec<DataFile>) -> Self {
+        let summary = append_summary(&files);
+
         self.operations
             .entry(APPEND_KEY.to_owned())
             .and_modify(|mut x| {
                 if let Operation::Append {
-                    branch: _,
-                    data_files: old,
-                    delete_files: _,
-                    additional_summary: None,
+                    data_files: old, ..
                 } = &mut x
                 {
                     old.extend_from_slice(&files)
@@ -135,7 +135,7 @@ impl<'table> TableTransaction<'table> {
                 branch: self.branch.clone(),
                 data_files: files,
                 delete_files: Vec::new(),
-                additional_summary: None,
+                additional_summary: summary,
             });
         self
     }


### PR DESCRIPTION
Related to https://github.com/Embucket/embucket/issues/411

It is difficult to calculate total size since we don't have access to previous snapshots/datafiles
delete operations still don't work

- added append operation summary in Spark format
  - "added-files-size"
  - "added-records"
  - "added-data-files"

- Full format is 
```json
"summary": {
	"operation": "append",
	"iceberg-version": "Apache Iceberg 1.7.0 (commit 5f7c992ca673bf41df1d37543b24d646c24568a9)",
	"total-delete-files": "0",
	"total-records": "88000000",
	"spark.app.id": "local-1731687692070",
	"engine-version": "3.5.3",
	"total-equality-deletes": "0",
	"app-id": "local-1731687692070",
	"changed-partition-count": "1",
	"total-data-files": "105",
	"added-files-size": "4740420564",
	"engine-name": "spark",
	"total-files-size": "8511955480",
	"added-data-files": "59",
	"total-position-deletes": "0",
	"added-records": "46000000"
},
```