### PR TITLE
Allow parquet writes for Struct data type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,25 +95,25 @@ dependencies = [
 
 [[package]]
 name = "apache-avro"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a81f4e6304e455a9d52cf8ab667cb2fcf792f2cee2a31c28800901a335ecd5"
+checksum = "1aef82843a0ec9f8b19567445ad2421ceeb1d711514384bdd3d49fe37102ee13"
 dependencies = [
  "bigdecimal",
- "bon",
  "digest",
+ "libflate",
  "log",
- "miniz_oxide",
  "num-bigint",
  "quad-rand",
- "rand 0.9.1",
+ "rand 0.8.5",
  "regex-lite",
  "serde",
  "serde_bytes",
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.69",
+ "typed-builder",
  "uuid",
 ]
 
@@ -1042,7 +1048,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1170,7 +1175,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1187,31 +1192,6 @@ dependencies = [
  "serde",
  "serde_repr",
  "serde_with",
-]
-
-[[package]]
-name = "bon"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
-dependencies = [
- "darling",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1497,6 +1477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,7 +1671,7 @@ dependencies = [
  "parquet",
  "rand 0.8.5",
  "regex",
- "sqlparser",
+ "sqlparser 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
  "url",
@@ -1753,7 +1748,7 @@ dependencies = [
  "parquet",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "web-time",
 ]
@@ -1929,7 +1924,7 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2239,7 +2234,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2266,7 +2261,7 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "url",
@@ -3151,7 +3146,7 @@ dependencies = [
  "serde_json",
  "testcontainers",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "uuid",
@@ -3172,7 +3167,7 @@ dependencies = [
  "serde_json",
  "testcontainers",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "uuid",
@@ -3233,8 +3228,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sqlparser",
- "thiserror",
+ "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ed416548dcfe4a73a3240bbf625fb9010a4925c8)",
+ "thiserror 2.0.12",
  "thrift",
  "tokio",
  "tracing",
@@ -3261,7 +3256,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_repr",
- "thiserror",
+ "thiserror 2.0.12",
  "url",
  "uuid",
 ]
@@ -3281,7 +3276,7 @@ dependencies = [
  "serde_json",
  "testcontainers",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "uuid",
@@ -3301,7 +3296,7 @@ dependencies = [
  "sqlx",
  "testcontainers",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "uuid",
@@ -3651,6 +3646,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,7 +4015,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -4468,7 +4487,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.27",
  "socket2 0.5.9",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -4488,7 +4507,7 @@ dependencies = [
  "rustls 0.23.27",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4781,6 +4800,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rsa"
@@ -5333,7 +5358,17 @@ checksum = "c4521174166bac1ff04fe16ef4524c70144cd29682a45978978ca3d7f4e0be11"
 dependencies = [
  "log",
  "recursive",
- "sqlparser_derive",
+ "sqlparser_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.55.0"
+source = "git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ed416548dcfe4a73a3240bbf625fb9010a4925c8#ed416548dcfe4a73a3240bbf625fb9010a4925c8"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive 0.3.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ed416548dcfe4a73a3240bbf625fb9010a4925c8)",
 ]
 
 [[package]]
@@ -5341,6 +5376,16 @@ name = "sqlparser_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.3.0"
+source = "git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ed416548dcfe4a73a3240bbf625fb9010a4925c8#ed416548dcfe4a73a3240bbf625fb9010a4925c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5390,7 +5435,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5475,7 +5520,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
  "whoami",
 ]
@@ -5512,7 +5557,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
  "whoami",
 ]
@@ -5536,7 +5581,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
  "url",
 ]
@@ -5608,15 +5653,15 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5734,7 +5779,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tar",
@@ -5753,11 +5798,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6087,6 +6152,26 @@ name = "twox-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+
+[[package]]
+name = "typed-builder"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,50 +1,50 @@
 [workspace]
 members = [
-    "catalogs/iceberg-file-catalog",
-    "catalogs/iceberg-glue-catalog",
-    "catalogs/iceberg-rest-catalog",
-    "catalogs/iceberg-s3tables-catalog",
-    "catalogs/iceberg-sql-catalog",
-    "datafusion-iceberg-sql",
-    "datafusion_iceberg",
-    "iceberg-rust",
-    "iceberg-rust-spec",
+  "catalogs/iceberg-file-catalog",
+  "catalogs/iceberg-glue-catalog",
+  "catalogs/iceberg-rest-catalog",
+  "catalogs/iceberg-s3tables-catalog",
+  "catalogs/iceberg-sql-catalog",
+  "datafusion-iceberg-sql",
+  "datafusion_iceberg",
+  "iceberg-rust",
+  "iceberg-rust-spec"
 ]
 
 resolver = "2"
 
 [workspace.dependencies]
-apache-avro = "0.18"
-arrow = "55"
-arrow-schema = "55"
+apache-avro = "0.17.0"
+arrow = "55.0.0"
+arrow-schema = "55.0.0"
 async-trait = "0.1"
 bytes = "1"
-chrono = { version = "0.4", default-features = false, features = [
-    "serde",
-    "clock",
-] }
-datafusion = "47"
-datafusion-common = "47"
-datafusion-execution = "47"
-datafusion-expr = "47"
-datafusion-functions = { version = "47", features = ["crypto_expressions"] }
-datafusion-functions-aggregate = "47"
-datafusion-sql = "47"
+chrono = { version = "0.4.0", default-features = false, features = ["serde", "clock"] }
+datafusion = { version= "47.0.0" }
+datafusion-sql = { version= "47.0.0" }
+datafusion-expr = { version= "47.0.0" }
+datafusion-common = { version= "47.0.0" }
+datafusion_datasource = { version= "47.0.0" }
+datafusion-execution = { version= "47.0.0" }
+datafusion-functions = { version= "47.0.0" }
+datafusion-functions-aggregate = { version = "47.0.0" }
 derive-getters = "0.5.0"
 derive_builder = "0.20"
 futures = "0.3.31"
 getrandom = { version = "0.3.1", features = ["std"] }
 itertools = "0.14.0"
-object_store = { version = "0.12", features = ["aws", "gcp"] }
+object_store = { version = "0.12.0", features = ["aws", "gcp"] }
 once_map = "0.4"
-parquet = { version = "55", features = ["async", "object_store"] }
+parquet = { version = "55.0.0", features = ["async", "object_store"] }
 pin-project-lite = "0.2"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
-sqlparser = { version = "0.55", features = ["visitor"] }
+sqlparser = { git = "https://github.com/Embucket/datafusion-sqlparser-rs.git", rev = "ed416548dcfe4a73a3240bbf625fb9010a4925c8", features = [
+  "visitor",
+] }
 thiserror = "2"
+url = "2.5.4"
+uuid = { version = "1.3.2", features = ["serde", "v4"] }
 tracing = "0.1"
 tracing-futures = "0.2"
-url = "^2.5"
-uuid = { version = "1.13.2", features = ["serde", "v4"] }

--- a/datafusion_iceberg/src/catalog/mod.rs
+++ b/datafusion_iceberg/src/catalog/mod.rs
@@ -1,5 +1,5 @@
 #[allow(clippy::module_inception)]
 pub mod catalog;
 pub mod catalog_list;
-pub(crate) mod mirror;
+pub mod mirror;
 pub mod schema;

--- a/datafusion_iceberg/src/catalog/schema.rs
+++ b/datafusion_iceberg/src/catalog/schema.rs
@@ -12,7 +12,7 @@ pub struct IcebergSchema {
 }
 
 impl IcebergSchema {
-    pub(crate) fn new(schema: Namespace, catalog: Arc<Mirror>) -> Self {
+    pub fn new(schema: Namespace, catalog: Arc<Mirror>) -> Self {
         IcebergSchema { schema, catalog }
     }
 }

--- a/datafusion_iceberg/src/lib.rs
+++ b/datafusion_iceberg/src/lib.rs
@@ -2,8 +2,8 @@ pub mod catalog;
 pub mod error;
 pub mod materialized_view;
 pub mod planner;
-mod pruning_statistics;
-mod statistics;
+pub mod pruning_statistics;
+pub mod statistics;
 pub mod table;
 
 pub use crate::table::DataFusionTable;

--- a/datafusion_iceberg/src/planner.rs
+++ b/datafusion_iceberg/src/planner.rs
@@ -410,10 +410,12 @@ async fn plan_drop_namespace(
     let namespace = Namespace::try_new(&[namespace_name.to_owned()])
         .map_err(|err| DataFusionError::External(Box::new(err)))?;
 
-    catalog
-        .drop_namespace(&namespace)
-        .await
-        .map_err(|err| DataFusionError::External(Box::new(err)))?;
+    if catalog.load_namespace(&namespace).await.is_ok() {
+        catalog
+            .drop_namespace(&namespace)
+            .await
+            .map_err(|err| DataFusionError::External(Box::new(err)))?;
+    }
 
     iceberg_catalog.deregister_schema(&namespace_name, false)?;
 

--- a/datafusion_iceberg/src/pruning_statistics.rs
+++ b/datafusion_iceberg/src/pruning_statistics.rs
@@ -45,13 +45,13 @@ use iceberg_rust::{
     table::ManifestPath,
 };
 
-pub(crate) struct PruneManifests<'table, 'manifests> {
+pub struct PruneManifests<'table, 'manifests> {
     partition_fields: &'table [BoundPartitionField<'table>],
     files: &'manifests [ManifestListEntry],
 }
 
 impl<'table, 'manifests> PruneManifests<'table, 'manifests> {
-    pub(crate) fn new(
+    pub fn new(
         partition_fields: &'table [BoundPartitionField<'table>],
         files: &'manifests [ManifestListEntry],
     ) -> Self {
@@ -142,14 +142,14 @@ impl PruningStatistics for PruneManifests<'_, '_> {
     }
 }
 
-pub(crate) struct PruneDataFiles<'table, 'manifests> {
+pub struct PruneDataFiles<'table, 'manifests> {
     schema: &'table Schema,
     arrow_schema: &'table ArrowSchema,
     files: &'manifests [(ManifestPath, ManifestEntry)],
 }
 
 impl<'table, 'manifests> PruneDataFiles<'table, 'manifests> {
-    pub(crate) fn new(
+    pub fn new(
         schema: &'table Schema,
         arrow_schema: &'table ArrowSchema,
         files: &'manifests [(ManifestPath, ManifestEntry)],
@@ -283,7 +283,7 @@ fn any_iter_to_array(
     }
 }
 
-pub(crate) fn transform_predicate(
+pub fn transform_predicate(
     expr: Expr,
     partition_fields: &[BoundPartitionField],
 ) -> Result<Expr, DataFusionError> {

--- a/datafusion_iceberg/src/statistics.rs
+++ b/datafusion_iceberg/src/statistics.rs
@@ -29,7 +29,7 @@ impl DataFusionTable {
     }
 }
 
-pub(crate) async fn table_statistics(
+pub async fn table_statistics(
     table: &Table,
     snapshot_range: &(Option<i64>, Option<i64>),
 ) -> Result<Statistics, Error> {
@@ -132,7 +132,7 @@ fn column_statistics<'a>(
     })
 }
 
-pub(crate) fn manifest_statistics(schema: &Schema, manifest: &ManifestEntry) -> Statistics {
+pub fn manifest_statistics(schema: &Schema, manifest: &ManifestEntry) -> Statistics {
     Statistics {
         num_rows: Precision::Exact(*manifest.data_file().record_count() as usize),
         total_byte_size: Precision::Exact(*manifest.data_file().file_size_in_bytes() as usize),

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -1367,20 +1367,29 @@ mod tests {
 
         ctx.register_table("orders", table.clone()).unwrap();
 
-        ctx.sql(
-            "INSERT INTO orders (id, customer_id, product_id, date, amount) VALUES
+        let res = ctx
+            .sql(
+                "INSERT INTO orders (id, customer_id, product_id, date, amount) VALUES
                 (1, 1, 1, '2020-01-01', 1),
                 (2, 2, 1, '2020-01-01', 1),
                 (3, 3, 1, '2020-01-01', 3),
                 (4, 1, 2, '2020-02-02', 1),
                 (5, 1, 1, '2020-02-02', 2),
                 (6, 3, 3, '2020-02-02', 3);",
-        )
-        .await
-        .expect("Failed to create query plan for insert")
-        .collect()
-        .await
-        .expect("Failed to insert values into table");
+            )
+            .await
+            .expect("Failed to create query plan for insert")
+            .collect()
+            .await
+            .expect("Failed to insert values into table");
+
+        let count = res[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()[0];
+        assert_eq!(count, 6);
 
         let batches = ctx
             .sql("select product_id, sum(amount) from orders where customer_id = 1 group by product_id;")

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -938,6 +938,11 @@ impl DataSink for IcebergDataSink {
             write_parquet_partitioned(table, data.map_err(Into::into), self.0.branch.as_deref())
                 .await?;
 
+        let count = metadata_files
+            .iter()
+            .map(|x| x.record_count())
+            .fold(0, |acc, x| acc + x);
+
         table
             .new_transaction(self.0.branch.as_deref())
             .append_data(metadata_files)
@@ -945,7 +950,7 @@ impl DataSink for IcebergDataSink {
             .await
             .map_err(DataFusionIcebergError::from)?;
 
-        Ok(0)
+        Ok(count as u64)
     }
     fn metrics(&self) -> Option<MetricsSet> {
         None

--- a/iceberg-rust-spec/src/arrow/schema.rs
+++ b/iceberg-rust-spec/src/arrow/schema.rs
@@ -146,10 +146,10 @@ impl TryFrom<&DataType> for Type {
     fn try_from(value: &DataType) -> Result<Self, Self::Error> {
         match value {
             DataType::Boolean => Ok(Type::Primitive(PrimitiveType::Boolean)),
-            DataType::Int8 | DataType::Int16 | DataType::Int32 => {
+            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::UInt32 => {
                 Ok(Type::Primitive(PrimitiveType::Int))
             }
-            DataType::Int64 => Ok(Type::Primitive(PrimitiveType::Long)),
+            DataType::Int64 | DataType::UInt64 => Ok(Type::Primitive(PrimitiveType::Long)),
             DataType::Float32 => Ok(Type::Primitive(PrimitiveType::Float)),
             DataType::Float64 => Ok(Type::Primitive(PrimitiveType::Double)),
             DataType::Decimal128(precision, scale) => Ok(Type::Primitive(PrimitiveType::Decimal {

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -193,6 +193,22 @@ impl TableMetadata {
             .ok_or_else(|| Error::InvalidFormat("partition spec".to_string()))
     }
 
+    /// Lookup snapshot by id.
+    #[inline]
+    pub fn snapshot_by_id(&self, snapshot_id: i64) -> Option<&Snapshot> {
+        self.snapshots.get(&snapshot_id)
+    }
+
+    /// Get the snapshot for a reference
+    /// Returns an option if the `ref_name` is not found
+    #[inline]
+    pub fn snapshot_for_ref(&self, ref_name: &str) -> Option<&Snapshot> {
+        self.refs.get(ref_name).map(|r| {
+            self.snapshot_by_id(r.snapshot_id)
+                .unwrap_or_else(|| panic!("Snapshot id of ref {} doesn't exist", ref_name))
+        })
+    }
+
     /// Gets the current partition fields for a given branch, binding them to their source schema fields
     ///
     /// # Arguments

--- a/iceberg-rust-spec/src/spec/types.rs
+++ b/iceberg-rust-spec/src/spec/types.rs
@@ -320,7 +320,7 @@ impl StructType {
                 .iter()
                 .find(|field| field.name == *part);
 
-            if i == parts.len() - 1 || current_field.is_none() {
+            if i == parts.len() - 1 || current_field.is_some() {
                 return current_field;
             }
 

--- a/iceberg-rust-spec/src/spec/types.rs
+++ b/iceberg-rust-spec/src/spec/types.rs
@@ -128,7 +128,8 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    let (precision, scale) = s
+    let binding = s.replace(" ", "");
+    let (precision, scale) = binding
         .trim_start_matches(r"decimal(")
         .trim_end_matches(')')
         .split_once(',')
@@ -136,7 +137,7 @@ where
 
     Ok(PrimitiveType::Decimal {
         precision: precision.parse().map_err(D::Error::custom)?,
-        scale: scale.trim().parse().map_err(D::Error::custom)?,
+        scale: scale.parse().map_err(D::Error::custom)?,
     })
 }
 

--- a/iceberg-rust/src/catalog/commit.rs
+++ b/iceberg-rust/src/catalog/commit.rs
@@ -209,7 +209,7 @@ pub enum TableRequirement {
         /// Name of ref
         r#ref: String,
         /// Snapshot id
-        snapshot_id: i64,
+        snapshot_id: Option<i64>,
     },
     /// The table's last assigned column id must match the requirement's `last-assigned-field-id`
     AssertLastAssignedFieldId {
@@ -348,11 +348,14 @@ pub fn check_table_requirements(
         // Assert create has to be check in another place
         TableRequirement::AssertCreate => true,
         TableRequirement::AssertTableUuid { uuid } => metadata.table_uuid == *uuid,
-        TableRequirement::AssertRefSnapshotId { r#ref, snapshot_id } => metadata
-            .refs
-            .get(r#ref)
-            .map(|id| id.snapshot_id == *snapshot_id)
-            .unwrap_or(false),
+        TableRequirement::AssertRefSnapshotId { r#ref, snapshot_id } => {
+            match (snapshot_id, metadata.snapshot_for_ref(r#ref)) {
+                (Some(snapshot_id), Some(snapshot_ref)) => {
+                    snapshot_ref.snapshot_id() == snapshot_id
+                }
+                _ => true,
+            }
+        }
         TableRequirement::AssertLastAssignedFieldId {
             last_assigned_field_id,
         } => metadata.last_column_id == *last_assigned_field_id,
@@ -454,6 +457,7 @@ pub fn apply_table_updates(
                     snapshot_id: *snapshot.snapshot_id(),
                     timestamp_ms: *snapshot.timestamp_ms(),
                 });
+                metadata.last_updated_ms = *snapshot.timestamp_ms();
                 metadata.last_sequence_number = *snapshot.sequence_number();
                 metadata.snapshots.insert(*snapshot.snapshot_id(), snapshot);
             }

--- a/iceberg-rust/src/file_format/parquet.rs
+++ b/iceberg-rust/src/file_format/parquet.rs
@@ -63,7 +63,7 @@ pub fn parquet_to_datafile(
         for column in row_group.columns() {
             let column_name = column.column_descr().name();
             let id = schema
-                .get_name(column_name)
+                .get_name(&column.column_path().parts().join("."))
                 .ok_or_else(|| Error::Schema(column_name.to_string(), "".to_string()))?
                 .id;
             column_sizes

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -495,7 +495,7 @@ impl Operation {
                 Ok((
                     Some(TableRequirement::AssertRefSnapshotId {
                         r#ref: branch.clone().unwrap_or("main".to_owned()),
-                        snapshot_id: *old_snapshot.snapshot_id(),
+                        snapshot_id: Some(*old_snapshot.snapshot_id()),
                     }),
                     vec![
                         TableUpdate::AddSnapshot { snapshot },

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -204,7 +204,7 @@ impl Operation {
                 Ok((
                     old_snapshot.map(|x| TableRequirement::AssertRefSnapshotId {
                         r#ref: branch.clone().unwrap_or("main".to_owned()),
-                        snapshot_id: *x.snapshot_id(),
+                        snapshot_id: Some(*x.snapshot_id()),
                     }),
                     vec![
                         TableUpdate::AddSnapshot { snapshot },
@@ -353,7 +353,7 @@ impl Operation {
                 Ok((
                     old_snapshot.map(|x| TableRequirement::AssertRefSnapshotId {
                         r#ref: branch.clone().unwrap_or("main".to_owned()),
-                        snapshot_id: *x.snapshot_id(),
+                        snapshot_id: Some(*x.snapshot_id()),
                     }),
                     vec![
                         TableUpdate::AddSnapshot { snapshot },
@@ -521,7 +521,7 @@ impl Operation {
                     .get(&key)
                     .map(|x| TableRequirement::AssertRefSnapshotId {
                         r#ref: key.clone(),
-                        snapshot_id: x.snapshot_id,
+                        snapshot_id: Some(x.snapshot_id),
                     }),
                 vec![TableUpdate::SetSnapshotRef {
                     ref_name: key,


### PR DESCRIPTION
Related to https://github.com/Embucket/embucket/issues/1352
only **column.column_path().parts()** cointains full path for column for Struct type
```rust
pub fn get_name(&self, name: &str) -> Option<&StructField> {
        let res = self.fields.iter().find(|field| field.name == name);
        if res.is_some() {
            return res;
        }
        let parts: Vec<&str> = name.split('.').collect();
        let mut current_struct = self;
        let mut current_field = None;
...
```

Example of arrow schema
```rust
arrow_schema Schema { fields: [Field { name: "address", data_type: Struct([Field { name: "state", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "2"} }, Field { name: "city", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "3"} }, Field { name: "street", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "4"} }, Field { name: "zip_code", data_type: Decimal128(38, 0), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "5"} }]), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "1"} }], metadata: {} }
```
for insert statement
```sql
CREATE TABLE customer (
  address OBJECT(
    state VARCHAR,
    city VARCHAR,
    street VARCHAR,
    zip_code NUMBER
  )
);
INSERT INTO customer SELECT
  {
    'state': 'CA',
    'city': 'San Mateo',
    'street': '450 Concar Drive',
    'zip_code': 94402
  }::OBJECT(
    state VARCHAR,
    city VARCHAR,
    street VARCHAR,
    zip_code NUMBER
  );
```
