### PR TITLE
Fix merge into manifest stats

### DIFF
--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -199,6 +199,14 @@ pub(crate) struct ManifestWriter<'schema, 'metadata> {
     table_metadata: &'metadata TableMetadata,
     manifest: ManifestListEntry,
     writer: AvroWriter<'schema, Vec<u8>>,
+    rewrite_summary: ManifestRewriteSummary,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ManifestRewriteSummary {
+    pub removed_data_files: i64,
+    pub removed_data_rows: i64,
+    pub removed_data_size: i64,
 }
 
 impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
@@ -303,6 +311,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             manifest,
             writer,
             table_metadata,
+            rewrite_summary: ManifestRewriteSummary::default(),
         })
     }
 
@@ -388,6 +397,10 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             },
         )?;
 
+        let mut existing_files_count = 0i32;
+        let mut existing_rows_count = 0i64;
+        let mut min_sequence_number = manifest.sequence_number;
+
         writer.extend(
             manifest_reader
                 .map(|entry| {
@@ -400,23 +413,32 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                     if entry.snapshot_id().is_none() {
                         *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
                     }
+                    if let Some(seq_num) = entry.sequence_number() {
+                        min_sequence_number = min_sequence_number.min(*seq_num);
+                    }
+                    if *entry.data_file().content() == Content::Data {
+                        existing_rows_count += entry.data_file().record_count();
+                    }
+                    existing_files_count += 1;
                     to_value(entry)
                 })
                 .filter_map(Result::ok),
         )?;
 
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
-
-        manifest.existing_files_count = Some(
-            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
-        );
-
-        manifest.added_files_count = None;
+        manifest.min_sequence_number = min_sequence_number.min(manifest.sequence_number);
+        manifest.existing_files_count = Some(existing_files_count);
+        manifest.added_files_count = Some(0);
+        manifest.deleted_files_count = Some(0);
+        manifest.added_rows_count = Some(0);
+        manifest.deleted_rows_count = Some(0);
+        manifest.existing_rows_count = Some(existing_rows_count);
 
         Ok(ManifestWriter {
             manifest,
             writer,
             table_metadata,
+            rewrite_summary: ManifestRewriteSummary::default(),
         })
     }
 
@@ -463,7 +485,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         table_metadata: &'metadata TableMetadata,
         branch: Option<&str>,
     ) -> Result<Self, Error> {
-        let manifest_reader = ManifestReader::new(bytes)?;
+        let fallback_schema = table_metadata.current_schema(None)?;
+        let manifest_reader = ManifestReader::new_with_fallback_schema(bytes, Some(fallback_schema.clone()))?;
 
         let mut writer = AvroWriter::new(schema, Vec::new());
 
@@ -518,37 +541,71 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             },
         )?;
 
-        writer.extend(manifest_reader.filter_map(|entry| {
-            let mut entry = entry
-                .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))
-                .unwrap();
-            if !filter.contains(entry.data_file().file_path()) {
-                *entry.status_mut() = Status::Existing;
-                if entry.sequence_number().is_none() {
-                    *entry.sequence_number_mut() = Some(manifest.sequence_number);
+        let mut entries = Vec::new();
+        let mut existing_files_count = 0i32;
+        let mut existing_rows_count = 0i64;
+        let mut min_sequence_number = manifest.sequence_number;
+
+        let mut removed_data_files = 0i64;
+        let mut removed_data_rows  = 0i64;
+        let mut removed_data_size = 0i64;
+
+        for entry in manifest_reader {
+            let mut entry =
+                entry.map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))?;
+
+            if filter.contains(entry.data_file().file_path()) {
+                if *entry.data_file().content() == Content::Data {
+                    removed_data_rows += entry.data_file().record_count();
                 }
-                if entry.snapshot_id().is_none() {
-                    *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
-                }
-                Some(to_value(entry).unwrap())
-            } else {
-                None
+                removed_data_size += entry.data_file().file_size_in_bytes();
+                removed_data_files += 1;
+                continue;
             }
-        }))?;
 
+            *entry.status_mut() = Status::Existing;
+            if entry.sequence_number().is_none() {
+                *entry.sequence_number_mut() = Some(manifest.sequence_number);
+            }
+            if entry.snapshot_id().is_none() {
+                *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
+            }
+
+            if let Some(seq_num) = entry.sequence_number() {
+                min_sequence_number = min_sequence_number.min(*seq_num);
+            }
+
+            if *entry.data_file().content() == Content::Data {
+                existing_rows_count += entry.data_file().record_count();
+            }
+            existing_files_count += 1;
+            entries.push(to_value(entry)?);
+        }
+
+        writer.extend(entries)?;
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
-
-        manifest.existing_files_count = Some(
-            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
-        );
-
-        manifest.added_files_count = None;
+        manifest.min_sequence_number = min_sequence_number.min(manifest.sequence_number);
+        manifest.existing_files_count = Some(existing_files_count);
+        manifest.added_files_count = Some(0);
+        manifest.deleted_files_count = Some(0);
+        manifest.added_rows_count = Some(0);
+        manifest.deleted_rows_count = Some(removed_data_rows);
+        manifest.existing_rows_count = Some(existing_rows_count);
 
         Ok(ManifestWriter {
             manifest,
             writer,
             table_metadata,
+            rewrite_summary: ManifestRewriteSummary {
+                removed_data_files,
+                removed_data_rows,
+                removed_data_size,
+            },
         })
+    }
+
+    pub(crate) fn rewrite_summary(&self) -> ManifestRewriteSummary {
+        self.rewrite_summary
     }
 
     /// Appends a manifest entry to the manifest file and updates summary statistics.

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -486,7 +486,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         branch: Option<&str>,
     ) -> Result<Self, Error> {
         let fallback_schema = table_metadata.current_schema(None)?;
-        let manifest_reader = ManifestReader::new_with_fallback_schema(bytes, Some(fallback_schema.clone()))?;
+        let manifest_reader =
+            ManifestReader::new_with_fallback_schema(bytes, Some(fallback_schema.clone()))?;
 
         let mut writer = AvroWriter::new(schema, Vec::new());
 
@@ -547,7 +548,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         let mut min_sequence_number = manifest.sequence_number;
 
         let mut removed_data_files = 0i64;
-        let mut removed_data_rows  = 0i64;
+        let mut removed_data_rows = 0i64;
         let mut removed_data_size = 0i64;
 
         for entry in manifest_reader {

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -356,7 +356,8 @@ async fn datafiles(
         let (bytes, path, sequence_number) = result;
 
         // Use new_with_fallback_schema to handle manifests with empty schemas
-        let reader = match ManifestReader::new_with_fallback_schema(bytes, fallback_schema.clone()) {
+        let reader = match ManifestReader::new_with_fallback_schema(bytes, fallback_schema.clone())
+        {
             Ok(reader) => reader,
             Err(e) => {
                 tracing::warn!(
@@ -365,7 +366,8 @@ async fn datafiles(
                     e
                 );
                 // Return an empty iterator for this manifest so we can continue with others
-                return Box::new(std::iter::empty()) as Box<dyn Iterator<Item = Result<(ManifestPath, ManifestEntry), Error>>>;
+                return Box::new(std::iter::empty())
+                    as Box<dyn Iterator<Item = Result<(ManifestPath, ManifestEntry), Error>>>;
             }
         };
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -684,7 +684,7 @@ impl Operation {
                         branch.as_deref(),
                     )?;
 
-                let rewrite_summary =manifest_list_writer
+                let rewrite_summary = manifest_list_writer
                     .append_and_filter(
                         manifests_to_overwrite,
                         &files_to_overwrite,
@@ -995,7 +995,7 @@ pub fn update_snapshot_summary<'files>(
     let total_data_files = old_total_data_files - removed.removed_data_files + added_data_files;
     let total_delete_files = old_total_delete_files + added_delete_files;
     let total_file_size = old_total_file_size - removed.removed_data_size + added_files_size;
-    
+
     // Build result map
     let mut result = HashMap::new();
     result.insert("total-records".to_string(), total_records.to_string());

--- a/iceberg-rust/tests/empty_schema_manifest_test.rs
+++ b/iceberg-rust/tests/empty_schema_manifest_test.rs
@@ -102,7 +102,10 @@ async fn test_zero_field_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_zero_field_schema();
 
     // Verify the manifest file was created
-    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
+    assert!(
+        !manifest_bytes.is_empty(),
+        "Manifest file should not be empty"
+    );
 
     // Write the manifest to object store
     let manifest_path = ObjectPath::from("warehouse/test/metadata/zero-field-schema-manifest.avro");
@@ -157,7 +160,10 @@ async fn test_empty_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_empty_schema();
 
     // Verify the manifest file was created
-    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
+    assert!(
+        !manifest_bytes.is_empty(),
+        "Manifest file should not be empty"
+    );
 
     // Write the corrupted manifest to object store to verify storage works
     let manifest_path =
@@ -472,8 +478,8 @@ fn create_manifest_with_empty_schema() -> Vec<u8> {
     }
     "#;
 
-    let schema =
-        AvroSchema::parse_str(manifest_entry_schema).expect("Failed to parse manifest entry schema");
+    let schema = AvroSchema::parse_str(manifest_entry_schema)
+        .expect("Failed to parse manifest entry schema");
 
     let mut writer = AvroWriter::new(&schema, Vec::new());
 
@@ -524,7 +530,10 @@ async fn test_empty_json_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_empty_json_schema();
 
     // Verify the manifest file was created
-    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
+    assert!(
+        !manifest_bytes.is_empty(),
+        "Manifest file should not be empty"
+    );
 
     // Write to object store
     let manifest_path =
@@ -615,8 +624,8 @@ fn create_manifest_with_empty_json_schema() -> Vec<u8> {
     }
     "#;
 
-    let schema =
-        AvroSchema::parse_str(manifest_entry_schema).expect("Failed to parse manifest entry schema");
+    let schema = AvroSchema::parse_str(manifest_entry_schema)
+        .expect("Failed to parse manifest entry schema");
 
     let mut writer = AvroWriter::new(&schema, Vec::new());
 
@@ -799,8 +808,7 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
                 .await
                 .expect("Failed to read original manifest bytes");
 
-            let corrupted_bytes =
-                create_corrupted_manifest_with_zero_field_schema(&original_bytes);
+            let corrupted_bytes = create_corrupted_manifest_with_zero_field_schema(&original_bytes);
 
             object_store_impl
                 .put(&path, corrupted_bytes.into())
@@ -825,8 +833,7 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
                 .await
                 .expect("Failed to read original manifest bytes");
 
-            let corrupted_bytes =
-                create_corrupted_manifest_with_zero_field_schema(&original_bytes);
+            let corrupted_bytes = create_corrupted_manifest_with_zero_field_schema(&original_bytes);
 
             object_store_impl
                 .put(&path, corrupted_bytes.into())
@@ -868,13 +875,14 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
             assert_eq!(
                 count, expected_count,
                 "Expected {} datafile(s) with fallback schema but got {}. Single manifest mode: {}",
-                expected_count,
-                count,
-                single_manifest_mode
+                expected_count, count, single_manifest_mode
             );
 
             println!("✓ SUCCESS: Manifest with zero-field schema successfully used table schema fallback!");
-            println!("✓ All {} datafiles were correctly returned despite corrupted manifest", count);
+            println!(
+                "✓ All {} datafiles were correctly returned despite corrupted manifest",
+                count
+            );
         }
         Err(e) => {
             // This is the CURRENT behavior - it fails completely

--- a/iceberg-rust/tests/empty_schema_manifest_test.rs
+++ b/iceberg-rust/tests/empty_schema_manifest_test.rs
@@ -72,7 +72,6 @@ use futures::stream;
 
 use iceberg_rust::arrow::write::write_parquet_partitioned;
 use iceberg_rust::catalog::Catalog;
-use iceberg_rust::error::Error;
 use iceberg_rust::object_store::{Bucket, ObjectStoreBuilder};
 use iceberg_rust::table::Table;
 use iceberg_rust_spec::spec::partition::PartitionSpec;


### PR DESCRIPTION
## Summary
- recompute manifest entries when reusing manifests, tracking removed file statistics for filtered overwrites
- propagate removal stats through manifest list filtering so overwrite manifest lists match the files actually written
- subtract overwritten files from snapshot summaries to keep totals consistent during merge/overwrite operations