### PR TITLE
Fix merge into manifest and snaphot stats 

### DIFF
--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -209,6 +209,13 @@ pub(crate) struct FilteredManifestStats {
     pub removed_file_size_bytes: i64,
 }
 
+impl FilteredManifestStats {
+    pub(crate) fn append(&mut self, stats: FilteredManifestStats) {
+        self.removed_file_size_bytes += stats.removed_file_size_bytes;
+        self.removed_records += stats.removed_records;
+        self.removed_file_size_bytes += stats.removed_file_size_bytes;
+    }
+}
 impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
     /// Creates a new ManifestWriter for writing manifest entries to a new manifest file.
     ///

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -213,7 +213,7 @@ impl FilteredManifestStats {
     pub(crate) fn append(&mut self, stats: FilteredManifestStats) {
         self.removed_file_size_bytes += stats.removed_file_size_bytes;
         self.removed_records += stats.removed_records;
-        self.removed_file_size_bytes += stats.removed_file_size_bytes;
+        self.removed_data_files += stats.removed_data_files;
     }
 }
 impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -337,6 +337,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
     ) -> Result<Self, Error> {
         let mut writer = AvroWriter::new(schema, Vec::new());
 
+        reset_manifest_summary(&mut manifest, table_metadata);
+
         writer.add_user_metadata(
             "format-version".to_string(),
             match table_metadata.format_version {
@@ -466,7 +468,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         let manifest_reader = ManifestReader::new(bytes)?;
 
         let mut writer = AvroWriter::new(schema, Vec::new());
-
+        reset_manifest_summary(&mut manifest, table_metadata);
         writer.add_user_metadata(
             "format-version".to_string(),
             match table_metadata.format_version {
@@ -727,6 +729,19 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         };
         Ok((self.manifest, future))
     }
+}
+
+fn reset_manifest_summary(manifest: &mut ManifestListEntry, table_metadata: &TableMetadata) {
+    manifest.sequence_number = table_metadata.last_sequence_number + 1;
+    manifest.min_sequence_number = 0;
+    manifest.manifest_length = 0;
+    manifest.added_files_count = Some(0);
+    manifest.existing_files_count = Some(0);
+    manifest.deleted_files_count = Some(0);
+    manifest.added_rows_count = Some(0);
+    manifest.existing_rows_count = Some(0);
+    manifest.deleted_rows_count = Some(0);
+    manifest.partitions = None;
 }
 
 #[allow(clippy::type_complexity)]

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -628,7 +628,12 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                     None => Some(1),
                 };
             }
-            Status::Deleted => (),
+            Status::Deleted => {
+                self.manifest.deleted_files_count = match self.manifest.deleted_files_count {
+                    Some(count) => Some(count + 1),
+                    None => Some(1),
+                };
+            },
         }
 
         self.manifest.added_rows_count = match self.manifest.added_rows_count {

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -423,8 +423,12 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         manifest.existing_files_count = Some(
             manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
         );
+        manifest.existing_rows_count = Some(
+            manifest.existing_rows_count.unwrap_or(0) + manifest.added_rows_count.unwrap_or(0),
+        );
 
         manifest.added_files_count = None;
+        manifest.added_rows_count = None;
 
         Ok(ManifestWriter {
             manifest,
@@ -482,6 +486,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         let mut writer = AvroWriter::new(schema, Vec::new());
         let mut filtered_stats = FilteredManifestStats::default();
+        let mut existing_files = 0i32;
+        let mut existing_rows = 0i64;
 
         writer.add_user_metadata(
             "format-version".to_string(),
@@ -546,6 +552,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 if entry.snapshot_id().is_none() {
                     *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
                 }
+                existing_files += 1;
+                existing_rows += entry.data_file().record_count();
                 Some(to_value(entry).unwrap())
             } else {
                 if *entry.data_file().content() == Content::Data {
@@ -559,12 +567,11 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
 
-        manifest.existing_files_count = Some(
-            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0)
-                - filtered_stats.removed_data_files,
-        );
+        manifest.existing_files_count = Some(existing_files);
+        manifest.existing_rows_count = Some(existing_rows);
 
         manifest.added_files_count = None;
+        manifest.added_rows_count = None;
 
         Ok((
             ManifestWriter {

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -350,9 +350,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         branch: Option<&str>,
     ) -> Result<Self, Error> {
         let mut writer = AvroWriter::new(schema, Vec::new());
-
-        reset_manifest_summary(&mut manifest, table_metadata);
-
         writer.add_user_metadata(
             "format-version".to_string(),
             match table_metadata.format_version {
@@ -420,6 +417,15 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 })
                 .filter_map(Result::ok),
         )?;
+
+        manifest.sequence_number = table_metadata.last_sequence_number + 1;
+
+        manifest.existing_files_count = Some(
+            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
+        );
+
+        manifest.added_files_count = None;
+
         Ok(ManifestWriter {
             manifest,
             writer,
@@ -477,7 +483,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         let mut writer = AvroWriter::new(schema, Vec::new());
         let mut filtered_stats = FilteredManifestStats::default();
 
-        reset_manifest_summary(&mut manifest, table_metadata);
         writer.add_user_metadata(
             "format-version".to_string(),
             match table_metadata.format_version {
@@ -529,30 +534,36 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             },
         )?;
 
-        let mut entries = Vec::new();
-        for entry in manifest_reader {
-            let mut entry =
-                entry.map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))?;
-
-            if filter.contains(entry.data_file().file_path()) {
+        writer.extend(manifest_reader.filter_map(|entry| {
+            let mut entry = entry
+                .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))
+                .unwrap();
+            if !filter.contains(entry.data_file().file_path()) {
+                *entry.status_mut() = Status::Existing;
+                if entry.sequence_number().is_none() {
+                    *entry.sequence_number_mut() = Some(manifest.sequence_number);
+                }
+                if entry.snapshot_id().is_none() {
+                    *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
+                }
+                Some(to_value(entry).unwrap())
+            } else {
                 if *entry.data_file().content() == Content::Data {
                     filtered_stats.removed_records += entry.data_file().record_count();
                 }
                 filtered_stats.removed_file_size_bytes += entry.data_file().file_size_in_bytes();
                 filtered_stats.removed_data_files += 1;
-                continue;
+                None
             }
+        }))?;
 
-            *entry.status_mut() = Status::Existing;
-            if entry.sequence_number().is_none() {
-                *entry.sequence_number_mut() = Some(manifest.sequence_number);
-            }
-            if entry.snapshot_id().is_none() {
-                *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
-            }
-            entries.push(to_value(entry)?);
-        }
-        writer.extend(entries)?;
+        manifest.sequence_number = table_metadata.last_sequence_number + 1;
+
+        manifest.existing_files_count = Some(
+            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
+        );
+
+        manifest.added_files_count = None;
 
         Ok((
             ManifestWriter {
@@ -757,19 +768,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             };
         }
     }
-}
-
-fn reset_manifest_summary(manifest: &mut ManifestListEntry, table_metadata: &TableMetadata) {
-    manifest.sequence_number = table_metadata.last_sequence_number + 1;
-    manifest.min_sequence_number = 0;
-    manifest.manifest_length = 0;
-    manifest.added_files_count = Some(0);
-    manifest.existing_files_count = Some(0);
-    manifest.deleted_files_count = Some(0);
-    manifest.added_rows_count = Some(0);
-    manifest.existing_rows_count = Some(0);
-    manifest.deleted_rows_count = Some(0);
-    manifest.partitions = None;
 }
 
 #[allow(clippy::type_complexity)]

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -560,7 +560,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
 
         manifest.existing_files_count = Some(
-            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
+            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0)
+                - filtered_stats.removed_data_files,
         );
 
         manifest.added_files_count = None;

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -473,7 +473,9 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         table_metadata: &'metadata TableMetadata,
         branch: Option<&str>,
     ) -> Result<Self, Error> {
-        let manifest_reader = ManifestReader::new(bytes)?;
+        let fallback_schema = table_metadata.current_schema(None)?;
+        let manifest_reader =
+            ManifestReader::new_with_fallback_schema(bytes, Some(fallback_schema.clone()))?;
 
         let mut writer = AvroWriter::new(schema, Vec::new());
         let mut filtered_stats = FilteredManifestStats::default();

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -837,8 +837,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
                 manifest.manifest_path = self.next_manifest_location();
 
-                let manifest_reader = ManifestReader::new(manifest_bytes.as_ref())?;
-
                 if let Some(filter) = filter {
                     let (manifest_writer, filtered_stats) =
                         ManifestWriter::from_existing_with_filter(
@@ -851,6 +849,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                         )?;
                     (manifest_writer, Some(filtered_stats))
                 } else {
+                    let manifest_reader = ManifestReader::new(manifest_bytes.as_ref())?;
                     let manifest_writer = ManifestWriter::from_existing(
                         manifest_reader,
                         manifest,

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -27,12 +27,6 @@ use iceberg_rust_spec::{
 use object_store::ObjectStore;
 use smallvec::SmallVec;
 
-use crate::{
-    error::Error,
-    table::datafiles,
-    util::{summary_to_rectangle, Rectangle, Vec4},
-};
-use crate::table::manifest::FilteredManifestStats;
 use super::{
     manifest::{ManifestReader, ManifestWriter},
     transaction::{
@@ -49,6 +43,12 @@ use super::{
             select_manifest_without_overwrites_unpartitioned, OverwriteManifest,
         },
     },
+};
+use crate::table::manifest::FilteredManifestStats;
+use crate::{
+    error::Error,
+    table::datafiles,
+    util::{summary_to_rectangle, Rectangle, Vec4},
 };
 
 type ReaderZip<'a, 'metadata, R> = Zip<AvroReader<'a, R>, Repeat<&'metadata TableMetadata>>;
@@ -703,11 +703,12 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         self.append_filtered(
             data_files,
             snapshot_id,
-            None::<fn(&Result<ManifestEntry, Error>) -> bool>,
+            None::<HashSet<String>>,
             object_store,
             content,
         )
         .await
+        .map(|_| ())
     }
 
     #[inline]
@@ -721,11 +722,12 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         self.append_filtered_concurrently(
             data_files,
             snapshot_id,
-            None::<fn(&Result<ManifestEntry, Error>) -> bool>,
+            None::<HashSet<String>>,
             object_store,
             content,
         )
         .await
+        .map(|(future, _)| future)
     }
 
     /// Appends data files to a single manifest with optional filtering and finalizes the manifest list.
@@ -758,7 +760,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// # Arguments
     /// * `data_files` - Iterator over manifest entries to append
     /// * `snapshot_id` - The snapshot ID for the new manifest
-    /// * `filter` - Optional filter function to apply to existing manifest entries when reusing
+    /// * `filter` - Optional set of file paths to exclude when reusing an existing manifest
     /// * `object_store` - The object store for writing files
     ///
     /// # Returns
@@ -787,24 +789,31 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         &mut self,
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
-        filter: Option<impl Fn(&Result<ManifestEntry, Error>) -> bool>,
+        filter: Option<HashSet<String>>,
         object_store: Arc<dyn ObjectStore>,
         content: Content,
-    ) -> Result<(), Error> {
-        self.append_filtered_concurrently(data_files, snapshot_id, filter, object_store, content)
-            .await?
+    ) -> Result<FilteredManifestStats, Error> {
+        let (future, stats) = self
+            .append_filtered_concurrently(data_files, snapshot_id, filter, object_store, content)
             .await?;
-        Ok(())
+        future.await?;
+        Ok(stats)
     }
 
     pub(crate) async fn append_filtered_concurrently(
         &mut self,
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
-        filter: Option<impl Fn(&Result<ManifestEntry, Error>) -> bool>,
+        filter: Option<HashSet<String>>,
         object_store: Arc<dyn ObjectStore>,
         content: Content,
-    ) -> Result<impl Future<Output = Result<(), Error>>, Error> {
+    ) -> Result<
+        (
+            impl Future<Output = Result<(), Error>>,
+            FilteredManifestStats,
+        ),
+        Error,
+    > {
         let selected_manifest = match content {
             Content::Data => self.selected_data_manifest.take(),
             Content::Deletes => self.selected_delete_manifest.take(),
@@ -830,9 +839,10 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             let manifest_reader = ManifestReader::new(manifest_bytes.as_ref())?;
 
             if let Some(filter) = filter {
-                ManifestWriter::from_existing(
-                    manifest_reader.filter(filter),
+                ManifestWriter::from_existing_with_filter(
+                    manifest_bytes.as_ref(),
                     manifest,
+                    &filter,
                     &manifest_schema,
                     self.table_metadata,
                     self.branch.as_deref(),
@@ -863,11 +873,12 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             manifest_writer.append(manifest_entry?)?;
         }
 
+        let filtered_stats = manifest_writer.filtered_stats();
         let (manifest, future) = manifest_writer.finish_concurrently(object_store.clone())?;
 
         self.writer.append_ser(manifest)?;
 
-        Ok(future)
+        Ok((future, filtered_stats))
     }
 
     /// Appends data files by splitting them across multiple manifests and finalizes the manifest list.
@@ -930,11 +941,12 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             data_files,
             snapshot_id,
             n_splits,
-            None::<fn(&Result<ManifestEntry, Error>) -> bool>,
+            None::<HashSet<String>>,
             object_store,
             content,
         )
         .await
+        .map(|(future, _)| future)
     }
 
     /// Appends data files across multiple manifests with optional filtering and finalizes the manifest list.
@@ -970,7 +982,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// * `data_files` - Iterator over manifest entries to append and split
     /// * `snapshot_id` - The snapshot ID for the new manifests
     /// * `n_splits` - The number of manifest files to create (should match `n_splits()` result)
-    /// * `filter` - Optional filter function to apply to existing manifest entries when reusing
+    /// * `filter` - Optional set of file paths to exclude when reusing an existing manifest
     /// * `object_store` - The object store for writing files
     ///
     /// # Returns
@@ -1004,21 +1016,22 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
         n_splits: u32,
-        filter: Option<impl Fn(&Result<ManifestEntry, Error>) -> bool>,
+        filter: Option<HashSet<String>>,
         object_store: Arc<dyn ObjectStore>,
         content: Content,
-    ) -> Result<(), Error> {
-        self.append_multiple_filtered_concurrently(
-            data_files,
-            snapshot_id,
-            n_splits,
-            filter,
-            object_store,
-            content,
-        )
-        .await?
-        .await?;
-        Ok(())
+    ) -> Result<FilteredManifestStats, Error> {
+        let (future, stats) = self
+            .append_multiple_filtered_concurrently(
+                data_files,
+                snapshot_id,
+                n_splits,
+                filter,
+                object_store,
+                content,
+            )
+            .await?;
+        future.await?;
+        Ok(stats)
     }
 
     pub(crate) async fn append_multiple_filtered_concurrently(
@@ -1026,10 +1039,17 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
         n_splits: u32,
-        filter: Option<impl Fn(&Result<ManifestEntry, Error>) -> bool>,
+        filter: Option<HashSet<String>>,
         object_store: Arc<dyn ObjectStore>,
         content: Content,
-    ) -> Result<impl Future<Output = Result<(), Error>>, Error> {
+    ) -> Result<
+        (
+            impl Future<Output = Result<(), Error>>,
+            FilteredManifestStats,
+        ),
+        Error,
+    > {
+        let mut removed_stats = FilteredManifestStats::default();
         let partition_fields = self
             .table_metadata
             .current_partition_fields(self.branch.as_deref())?;
@@ -1067,8 +1087,27 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             (selected_manifest, selected_manifest_bytes_opt)
         {
             let manifest_bytes = manifest_bytes.await??;
-            let manifest_reader = ManifestReader::new(&*manifest_bytes)?.map(|entry| {
-                let mut entry = entry?;
+
+            let manifest_reader = ManifestReader::new(&*manifest_bytes)?.filter_map(|entry| {
+                let mut entry = match entry {
+                    Ok(entry) => entry,
+                    Err(err) => return Some(Err(err)),
+                };
+
+                if let Some(files_to_filter) = filter.as_ref() {
+                    if files_to_filter.contains(entry.data_file().file_path()) {
+                        if *entry.data_file().content()
+                            == iceberg_rust_spec::manifest::Content::Data
+                        {
+                            removed_stats.removed_records += entry.data_file().record_count();
+                        }
+                        removed_stats.removed_file_size_bytes +=
+                            entry.data_file().file_size_in_bytes();
+                        removed_stats.removed_data_files += 1;
+                        return None;
+                    }
+                }
+
                 *entry.status_mut() = Status::Existing;
                 if entry.sequence_number().is_none() {
                     *entry.sequence_number_mut() = Some(manifest.sequence_number);
@@ -1076,24 +1115,15 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 if entry.snapshot_id().is_none() {
                     *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
                 }
-                Ok(entry)
+                Some(Ok(entry))
             });
 
-            if let Some(filter) = filter {
-                split_datafiles(
-                    data_files.chain(manifest_reader.filter(filter)),
-                    bounds,
-                    &partition_column_names,
-                    n_splits,
-                )?
-            } else {
-                split_datafiles(
-                    data_files.chain(manifest_reader),
-                    bounds,
-                    &partition_column_names,
-                    n_splits,
-                )?
-            }
+            split_datafiles(
+                data_files.chain(manifest_reader),
+                bounds,
+                &partition_column_names,
+                n_splits,
+            )?
         } else {
             split_datafiles(data_files, bounds, &partition_column_names, n_splits)?
         };
@@ -1126,7 +1156,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
         let future = futures::future::try_join_all(manifest_futures).map_ok(|_| ());
 
-        Ok(future)
+        Ok((future, removed_stats))
     }
 
     pub(crate) async fn finish(
@@ -1260,7 +1290,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
                 manifest.manifest_path = manifest_location;
 
-                let (manifest_writer, filtered_stats) =  ManifestWriter::from_existing_with_filter(
+                let manifest_writer = ManifestWriter::from_existing_with_filter(
                     &bytes,
                     manifest,
                     &data_files_to_filter,
@@ -1268,6 +1298,9 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                     table_metadata,
                     branch.as_deref(),
                 )?;
+
+                // Capture filtered statistics
+                let filtered_stats = manifest_writer.filtered_stats();
 
                 let new_manifest = manifest_writer.finish(object_store.clone()).await?;
 
@@ -1278,7 +1311,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         for manifest_res in join_all(futures).await {
             let (manifest, filtered_stats) = manifest_res?;
             removed_stats.removed_data_files += filtered_stats.removed_data_files;
-            removed_stats.removed_delete_files += filtered_stats.removed_delete_files;
             removed_stats.removed_records += filtered_stats.removed_records;
             removed_stats.removed_file_size_bytes += filtered_stats.removed_file_size_bytes;
             self.writer.append_ser(manifest)?;

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -356,7 +356,8 @@ async fn datafiles(
         let (bytes, path, sequence_number) = result;
 
         // Use new_with_fallback_schema to handle manifests with empty schemas
-        let reader = match ManifestReader::new_with_fallback_schema(bytes, fallback_schema.clone()) {
+        let reader = match ManifestReader::new_with_fallback_schema(bytes, fallback_schema.clone())
+        {
             Ok(reader) => reader,
             Err(e) => {
                 tracing::warn!(
@@ -365,7 +366,8 @@ async fn datafiles(
                     e
                 );
                 // Return an empty iterator for this manifest so we can continue with others
-                return Box::new(std::iter::empty()) as Box<dyn Iterator<Item = Result<(ManifestPath, ManifestEntry), Error>>>;
+                return Box::new(std::iter::empty())
+                    as Box<dyn Iterator<Item = Result<(ManifestPath, ManifestEntry), Error>>>;
             }
         };
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -742,7 +742,10 @@ impl Operation {
                         .await?
                 };
 
-                filtered_stats.append(selected_filter_stats);
+                if let Some(selected_filter_stats) = selected_filter_stats {
+                    filtered_stats.append(selected_filter_stats);
+                }
+
                 let new_manifest_list_location = manifest_list_writer
                     .finish(snapshot_id, object_store)
                     .await?;
@@ -994,7 +997,7 @@ pub fn update_snapshot_summary<'files>(
 
 pub(crate) fn update_snapshot_summary_by_filtered_stats(
     summary: &mut HashMap<String, String>,
-    stats: FilteredManifestStats
+    stats: FilteredManifestStats,
 ) {
     let mut subtract_from_summary = |key: &str, delta: i64, add: bool| {
         if delta == 0 {
@@ -1016,7 +1019,11 @@ pub(crate) fn update_snapshot_summary_by_filtered_stats(
     subtract_from_summary("deleted-data-files", stats.removed_data_files.into(), true);
     subtract_from_summary("deleted-records", stats.removed_records, true);
     subtract_from_summary("total-data-files", stats.removed_data_files.into(), false);
-    subtract_from_summary("total-file-size-bytes", stats.removed_file_size_bytes, false);
+    subtract_from_summary(
+        "total-file-size-bytes",
+        stats.removed_file_size_bytes,
+        false,
+    );
 }
 
 pub(crate) fn new_manifest_location(

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -767,6 +767,11 @@ impl Operation {
                     summary_fields.insert(key.to_string(), updated.to_string());
                 };
                 subtract_from_summary("total-records", filtered_stats.removed_records);
+                subtract_from_summary(
+                    "deleted-data-files",
+                    -filtered_stats.removed_data_files as i64,
+                );
+                subtract_from_summary("deleted-records", -filtered_stats.removed_records);
                 subtract_from_summary("total-data-files", filtered_stats.removed_data_files.into());
                 subtract_from_summary(
                     "total-file-size-bytes",

--- a/iceberg-rust/tests/empty_schema_manifest_test.rs
+++ b/iceberg-rust/tests/empty_schema_manifest_test.rs
@@ -902,7 +902,7 @@ fn create_record_batch(ids: Vec<i64>, data: Vec<&str>) -> RecordBatch {
         Arc::new(schema),
         vec![Arc::new(id_array), Arc::new(data_array)],
     )
-        .expect("Failed to create RecordBatch")
+    .expect("Failed to create RecordBatch")
 }
 
 /// Creates a corrupted version of a manifest file with zero-field schema.

--- a/iceberg-rust/tests/empty_schema_manifest_test.rs
+++ b/iceberg-rust/tests/empty_schema_manifest_test.rs
@@ -103,7 +103,10 @@ async fn test_zero_field_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_zero_field_schema();
 
     // Verify the manifest file was created
-    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
+    assert!(
+        !manifest_bytes.is_empty(),
+        "Manifest file should not be empty"
+    );
 
     // Write the manifest to object store
     let manifest_path = ObjectPath::from("warehouse/test/metadata/zero-field-schema-manifest.avro");
@@ -158,7 +161,10 @@ async fn test_empty_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_empty_schema();
 
     // Verify the manifest file was created
-    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
+    assert!(
+        !manifest_bytes.is_empty(),
+        "Manifest file should not be empty"
+    );
 
     // Write the corrupted manifest to object store to verify storage works
     let manifest_path =
@@ -473,8 +479,8 @@ fn create_manifest_with_empty_schema() -> Vec<u8> {
     }
     "#;
 
-    let schema =
-        AvroSchema::parse_str(manifest_entry_schema).expect("Failed to parse manifest entry schema");
+    let schema = AvroSchema::parse_str(manifest_entry_schema)
+        .expect("Failed to parse manifest entry schema");
 
     let mut writer = AvroWriter::new(&schema, Vec::new());
 
@@ -525,7 +531,10 @@ async fn test_empty_json_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_empty_json_schema();
 
     // Verify the manifest file was created
-    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
+    assert!(
+        !manifest_bytes.is_empty(),
+        "Manifest file should not be empty"
+    );
 
     // Write to object store
     let manifest_path =
@@ -616,8 +625,8 @@ fn create_manifest_with_empty_json_schema() -> Vec<u8> {
     }
     "#;
 
-    let schema =
-        AvroSchema::parse_str(manifest_entry_schema).expect("Failed to parse manifest entry schema");
+    let schema = AvroSchema::parse_str(manifest_entry_schema)
+        .expect("Failed to parse manifest entry schema");
 
     let mut writer = AvroWriter::new(&schema, Vec::new());
 
@@ -800,8 +809,7 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
                 .await
                 .expect("Failed to read original manifest bytes");
 
-            let corrupted_bytes =
-                create_corrupted_manifest_with_zero_field_schema(&original_bytes);
+            let corrupted_bytes = create_corrupted_manifest_with_zero_field_schema(&original_bytes);
 
             object_store_impl
                 .put(&path, corrupted_bytes.into())
@@ -826,8 +834,7 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
                 .await
                 .expect("Failed to read original manifest bytes");
 
-            let corrupted_bytes =
-                create_corrupted_manifest_with_zero_field_schema(&original_bytes);
+            let corrupted_bytes = create_corrupted_manifest_with_zero_field_schema(&original_bytes);
 
             object_store_impl
                 .put(&path, corrupted_bytes.into())
@@ -869,13 +876,14 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
             assert_eq!(
                 count, expected_count,
                 "Expected {} datafile(s) with fallback schema but got {}. Single manifest mode: {}",
-                expected_count,
-                count,
-                single_manifest_mode
+                expected_count, count, single_manifest_mode
             );
 
             println!("✓ SUCCESS: Manifest with zero-field schema successfully used table schema fallback!");
-            println!("✓ All {} datafiles were correctly returned despite corrupted manifest", count);
+            println!(
+                "✓ All {} datafiles were correctly returned despite corrupted manifest",
+                count
+            );
         }
         Err(e) => {
             // This is the CURRENT behavior - it fails completely

--- a/iceberg-rust/tests/empty_schema_manifest_test.rs
+++ b/iceberg-rust/tests/empty_schema_manifest_test.rs
@@ -103,10 +103,7 @@ async fn test_zero_field_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_zero_field_schema();
 
     // Verify the manifest file was created
-    assert!(
-        !manifest_bytes.is_empty(),
-        "Manifest file should not be empty"
-    );
+    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
 
     // Write the manifest to object store
     let manifest_path = ObjectPath::from("warehouse/test/metadata/zero-field-schema-manifest.avro");
@@ -161,10 +158,7 @@ async fn test_empty_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_empty_schema();
 
     // Verify the manifest file was created
-    assert!(
-        !manifest_bytes.is_empty(),
-        "Manifest file should not be empty"
-    );
+    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
 
     // Write the corrupted manifest to object store to verify storage works
     let manifest_path =
@@ -479,8 +473,8 @@ fn create_manifest_with_empty_schema() -> Vec<u8> {
     }
     "#;
 
-    let schema = AvroSchema::parse_str(manifest_entry_schema)
-        .expect("Failed to parse manifest entry schema");
+    let schema =
+        AvroSchema::parse_str(manifest_entry_schema).expect("Failed to parse manifest entry schema");
 
     let mut writer = AvroWriter::new(&schema, Vec::new());
 
@@ -531,10 +525,7 @@ async fn test_empty_json_schema_in_manifest_metadata() {
     let manifest_bytes = create_manifest_with_empty_json_schema();
 
     // Verify the manifest file was created
-    assert!(
-        !manifest_bytes.is_empty(),
-        "Manifest file should not be empty"
-    );
+    assert!(!manifest_bytes.is_empty(), "Manifest file should not be empty");
 
     // Write to object store
     let manifest_path =
@@ -625,8 +616,8 @@ fn create_manifest_with_empty_json_schema() -> Vec<u8> {
     }
     "#;
 
-    let schema = AvroSchema::parse_str(manifest_entry_schema)
-        .expect("Failed to parse manifest entry schema");
+    let schema =
+        AvroSchema::parse_str(manifest_entry_schema).expect("Failed to parse manifest entry schema");
 
     let mut writer = AvroWriter::new(&schema, Vec::new());
 
@@ -809,7 +800,8 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
                 .await
                 .expect("Failed to read original manifest bytes");
 
-            let corrupted_bytes = create_corrupted_manifest_with_zero_field_schema(&original_bytes);
+            let corrupted_bytes =
+                create_corrupted_manifest_with_zero_field_schema(&original_bytes);
 
             object_store_impl
                 .put(&path, corrupted_bytes.into())
@@ -834,7 +826,8 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
                 .await
                 .expect("Failed to read original manifest bytes");
 
-            let corrupted_bytes = create_corrupted_manifest_with_zero_field_schema(&original_bytes);
+            let corrupted_bytes =
+                create_corrupted_manifest_with_zero_field_schema(&original_bytes);
 
             object_store_impl
                 .put(&path, corrupted_bytes.into())
@@ -876,14 +869,13 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
             assert_eq!(
                 count, expected_count,
                 "Expected {} datafile(s) with fallback schema but got {}. Single manifest mode: {}",
-                expected_count, count, single_manifest_mode
+                expected_count,
+                count,
+                single_manifest_mode
             );
 
             println!("✓ SUCCESS: Manifest with zero-field schema successfully used table schema fallback!");
-            println!(
-                "✓ All {} datafiles were correctly returned despite corrupted manifest",
-                count
-            );
+            println!("✓ All {} datafiles were correctly returned despite corrupted manifest", count);
         }
         Err(e) => {
             // This is the CURRENT behavior - it fails completely
@@ -910,7 +902,7 @@ fn create_record_batch(ids: Vec<i64>, data: Vec<&str>) -> RecordBatch {
         Arc::new(schema),
         vec![Arc::new(id_array), Arc::new(data_array)],
     )
-    .expect("Failed to create RecordBatch")
+        .expect("Failed to create RecordBatch")
 }
 
 /// Creates a corrupted version of a manifest file with zero-field schema.


### PR DESCRIPTION
## Summary
- recompute manifest entries when reusing manifests, tracking removed file statistics for filtered overwrites
- propagate removal stats through manifest list filtering so overwrite manifest lists match the files actually written
- subtract overwritten files from snapshot summaries to keep totals consistent during merge/overwrite operations