### PR TITLE
Adjust manifest futures to include removal stats

### DIFF
--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -217,12 +217,12 @@ mod _serde {
                 sequence_number: value.sequence_number,
                 min_sequence_number: value.min_sequence_number,
                 added_snapshot_id: value.added_snapshot_id,
-                added_files_count: value.added_files_count.unwrap(),
-                existing_files_count: value.existing_files_count.unwrap(),
-                deleted_files_count: value.deleted_files_count.unwrap(),
-                added_rows_count: value.added_rows_count.unwrap(),
-                existing_rows_count: value.existing_rows_count.unwrap(),
-                deleted_rows_count: value.deleted_rows_count.unwrap(),
+                added_files_count: value.added_files_count.unwrap_or(0),
+                existing_files_count: value.existing_files_count.unwrap_or(0),
+                deleted_files_count: value.deleted_files_count.unwrap_or(0),
+                added_rows_count: value.added_rows_count.unwrap_or(0),
+                existing_rows_count: value.existing_rows_count.unwrap_or(0),
+                deleted_rows_count: value.deleted_rows_count.unwrap_or(0),
                 partitions: value
                     .partitions
                     .map(|v| v.into_iter().map(Into::into).collect()),

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -685,15 +685,15 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             Some(count) => Some(count + added_rows_count),
             None => Some(added_rows_count),
         };
-        
+
         self.manifest.existing_rows_count = match self.manifest.existing_rows_count {
-            Some(count) => Some(count + deleted_rows_count),
-            None => Some(deleted_rows_count),
-        };
-        
-        self.manifest.deleted_rows_count = match self.manifest.deleted_rows_count {
             Some(count) => Some(count + existing_rows_count),
             None => Some(existing_rows_count),
+        };
+
+        self.manifest.deleted_rows_count = match self.manifest.deleted_rows_count {
+            Some(count) => Some(count + deleted_rows_count),
+            None => Some(deleted_rows_count),
         };
 
         Ok(())

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -1150,7 +1150,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             split_datafiles(data_files, bounds, &partition_column_names, n_splits)?
         };
 
-        let (manifests, manifest_futures) = splits
+        let (mut manifests, mut manifest_futures) = splits
             .into_iter()
             .map(|entries| {
                 let manifest_location = self.next_manifest_location();
@@ -1172,6 +1172,25 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             })
             .collect::<Result<(Vec<_>, Vec<_>), _>>()?;
 
+
+        if let Some(removed_stats) = removed_stats.as_ref() {
+            if removed_stats.removed_data_files > 0 {
+                let manifest_location = self.next_manifest_location();
+                let mut manifest_writer = ManifestWriter::new(
+                    &manifest_location,
+                    snapshot_id,
+                    &manifest_schema,
+                    self.table_metadata,
+                    content,
+                    self.branch.as_deref(),
+                )?;
+                manifest_writer.apply_filtered_stats(removed_stats);
+                let (manifest, future) =
+                    manifest_writer.finish_concurrently(object_store.clone())?;
+                manifests.push(manifest);
+                manifest_futures.push(future);
+            }
+        }
         for manifest in manifests {
             self.writer.append_ser(manifest)?;
         }

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -26,7 +26,7 @@ use iceberg_rust_spec::{
 };
 use object_store::ObjectStore;
 use smallvec::SmallVec;
-use iceberg_rust_spec::manifest::DataFileBuilder;
+
 use super::{
     manifest::{ManifestReader, ManifestWriter},
     transaction::{
@@ -1182,7 +1182,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             })
             .collect::<Result<(Vec<_>, Vec<_>), _>>()?;
 
-        // Add additional manifest with filtered data files
+        // Add additional manifest with filtered (deleted) data files
         if let Some(removed_stats) = removed_stats.as_ref() {
             if removed_stats.removed_data_files > 0 {
                 let manifest_location = self.next_manifest_location();
@@ -1197,7 +1197,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 for manifest_entry in filtered_files {
                     manifest_writer.append(manifest_entry)?;
                 }
-                manifest_writer.apply_filtered_stats(removed_stats);
+                manifest_writer.adjust_filtered_stats(removed_stats);
                 let (manifest, future) =
                     manifest_writer.finish_concurrently(object_store.clone())?;
                 manifests.push(manifest);

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -26,7 +26,7 @@ use iceberg_rust_spec::{
 };
 use object_store::ObjectStore;
 use smallvec::SmallVec;
-
+use iceberg_rust_spec::manifest::DataFileBuilder;
 use super::{
     manifest::{ManifestReader, ManifestWriter},
     transaction::{
@@ -1194,7 +1194,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                     *manifest_entry.status_mut() = Status::Deleted;
                     manifest_writer.append(manifest_entry)?;
                 }
-                manifest_writer.apply_filtered_stats(removed_stats);
                 let (manifest, future) =
                     manifest_writer.finish_concurrently(object_store.clone())?;
                 manifests.push(manifest);

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -1197,7 +1197,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 for manifest_entry in filtered_files {
                     manifest_writer.append(manifest_entry)?;
                 }
-                manifest_writer.adjust_filtered_stats(removed_stats);
                 let (manifest, future) =
                     manifest_writer.finish_concurrently(object_store.clone())?;
                 manifests.push(manifest);

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -1061,7 +1061,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         Error,
     > {
         let mut removed_stats = if filter.is_some() {
-            Some(FilteredManifestStats::new())
+            Some(FilteredManifestStats::default())
         } else {
             None
         };


### PR DESCRIPTION
## Summary
- retain concurrent manifest collection structure while allowing extension for removed-file manifests
- write an additional manifest when filtered removals are present so deleted statistics are recorded
