### PR TITLE
Save filtered manifests separatelly 

### DIFF
--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -836,6 +836,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 let manifest_bytes = manifest_bytes.await??;
 
                 manifest.manifest_path = self.next_manifest_location();
+                manifest.added_snapshot_id = snapshot_id;
 
                 if let Some(filter) = filter {
                     let (manifest_writer, filtered_stats) =
@@ -881,12 +882,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             manifest_writer.append(manifest_entry?)?;
         }
 
-        if let Some(filtered_stats) = filtered_stats {
-            manifest_writer.apply_filtered_stats(&filtered_stats);
-        }
-
         let (manifest, future) = manifest_writer.finish_concurrently(object_store.clone())?;
-
         self.writer.append_ser(manifest)?;
 
         Ok((future, filtered_stats))
@@ -1060,7 +1056,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         ),
         Error,
     > {
-        let mut removed_stats = if filter.is_some() {
+        let mut filtered_stats = if filter.is_some() {
             Some(FilteredManifestStats::default())
         } else {
             None
@@ -1098,10 +1094,9 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         let selected_manifest_bytes_opt = prefetch_manifest(&selected_manifest, &object_store);
 
         // Split datafiles
-        let (splits, filtered_files) = if let (Some(manifest), Some(manifest_bytes)) =
+        let splits = if let (Some(manifest), Some(manifest_bytes)) =
             (selected_manifest, selected_manifest_bytes_opt)
         {
-            let mut filtered_files = Vec::new();
             let manifest_bytes = manifest_bytes.await??;
             let fallback_schema = self.table_metadata.current_schema(None)?;
 
@@ -1109,58 +1104,52 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 manifest_bytes.as_ref(),
                 Some(fallback_schema.clone()),
             )?
-                .filter_map(|entry| {
-                    let mut entry = match entry {
-                        Ok(entry) => entry,
-                        Err(err) => return Some(Err(err)),
-                    };
+            .filter_map(|entry| {
+                let mut entry = match entry {
+                    Ok(entry) => entry,
+                    Err(err) => return Some(Err(err)),
+                };
 
-                    if let (Some(files_to_filter), Some(removed_stats)) =
-                        (filter.as_ref(), &mut removed_stats)
-                    {
-                        if entry.sequence_number().is_none() {
-                            *entry.sequence_number_mut() = Some(manifest.sequence_number);
-                        }
-                        if entry.snapshot_id().is_none() {
-                            *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
-                        }
-
-                        if files_to_filter.contains(entry.data_file().file_path()) {
-                            if *entry.data_file().content()
-                                == iceberg_rust_spec::manifest::Content::Data
-                            {
-                                removed_stats.removed_records += entry.data_file().record_count();
-                            }
-                            removed_stats.removed_file_size_bytes +=
-                                entry.data_file().file_size_in_bytes();
-                            removed_stats.removed_data_files += 1;
-
-                            *entry.status_mut() = Status::Deleted;
-                            filtered_files.push(entry);
-                            return None;
-                        }
+                if let (Some(files_to_filter), Some(filtered_stats)) =
+                    (filter.as_ref(), &mut filtered_stats)
+                {
+                    if entry.sequence_number().is_none() {
+                        *entry.sequence_number_mut() = Some(manifest.sequence_number);
                     }
-                    *entry.status_mut() = Status::Existing;
-                    Some(Ok(entry))
-                });
+                    if entry.snapshot_id().is_none() {
+                        *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
+                    }
 
-            (
-                split_datafiles(
-                    data_files.chain(manifest_reader),
-                    bounds,
-                    &partition_column_names,
-                    n_splits,
-                )?,
-                filtered_files,
-            )
+                    if files_to_filter.contains(entry.data_file().file_path()) {
+                        if *entry.data_file().content()
+                            == iceberg_rust_spec::manifest::Content::Data
+                        {
+                            filtered_stats.removed_records += entry.data_file().record_count();
+                        }
+                        filtered_stats.removed_file_size_bytes +=
+                            entry.data_file().file_size_in_bytes();
+                        filtered_stats.removed_data_files += 1;
+
+                        *entry.status_mut() = Status::Deleted;
+                        filtered_stats.filtered_entries.push(entry);
+                        return None;
+                    }
+                }
+                *entry.status_mut() = Status::Existing;
+                Some(Ok(entry))
+            });
+
+            split_datafiles(
+                data_files.chain(manifest_reader),
+                bounds,
+                &partition_column_names,
+                n_splits,
+            )?
         } else {
-            (
-                split_datafiles(data_files, bounds, &partition_column_names, n_splits)?,
-                Vec::new(),
-            )
+            split_datafiles(data_files, bounds, &partition_column_names, n_splits)?
         };
 
-        let (mut manifests, mut manifest_futures) = splits
+        let (manifests, manifest_futures) = splits
             .into_iter()
             .map(|entries| {
                 let manifest_location = self.next_manifest_location();
@@ -1182,35 +1171,13 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             })
             .collect::<Result<(Vec<_>, Vec<_>), _>>()?;
 
-        // Add additional manifest with filtered (deleted) data files
-        if let Some(removed_stats) = removed_stats.as_ref() {
-            if removed_stats.removed_data_files > 0 {
-                let manifest_location = self.next_manifest_location();
-                let mut manifest_writer = ManifestWriter::new(
-                    &manifest_location,
-                    snapshot_id,
-                    &manifest_schema,
-                    self.table_metadata,
-                    content,
-                    self.branch.as_deref(),
-                )?;
-                for manifest_entry in filtered_files {
-                    manifest_writer.append(manifest_entry)?;
-                }
-                let (manifest, future) =
-                    manifest_writer.finish_concurrently(object_store.clone())?;
-                manifests.push(manifest);
-                manifest_futures.push(future);
-            }
-        }
-
         for manifest in manifests {
             self.writer.append_ser(manifest)?;
         }
 
         let future = futures::future::try_join_all(manifest_futures).map_ok(|_| ());
 
-        Ok((future, removed_stats))
+        Ok((future, filtered_stats))
     }
 
     pub(crate) async fn finish(
@@ -1311,6 +1278,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         manifests_to_overwrite: Vec<ManifestListEntry>,
         data_files_to_filter: &HashMap<String, Vec<String>>,
         object_store: Arc<dyn ObjectStore>,
+        snapshot_id: i64,
     ) -> Result<FilteredManifestStats, Error> {
         let partition_fields = self
             .table_metadata
@@ -1343,20 +1311,16 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                     .await?;
 
                 manifest.manifest_path = manifest_location;
+                manifest.added_snapshot_id = snapshot_id;
 
-                let (mut manifest_writer, filtered_stats) =
-                    ManifestWriter::from_existing_with_filter(
-                        &bytes,
-                        manifest,
-                        &data_files_to_filter,
-                        &manifest_schema,
-                        table_metadata,
-                        branch.as_deref(),
-                    )?;
-
-                manifest_writer.apply_filtered_stats(&filtered_stats);
-
-                // Capture filtered statistics
+                let (manifest_writer, filtered_stats) = ManifestWriter::from_existing_with_filter(
+                    &bytes,
+                    manifest,
+                    &data_files_to_filter,
+                    &manifest_schema,
+                    table_metadata,
+                    branch.as_deref(),
+                )?;
 
                 let new_manifest = manifest_writer.finish(object_store.clone()).await?;
 
@@ -1369,6 +1333,9 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             removed_stats.removed_data_files += filtered_stats.removed_data_files;
             removed_stats.removed_records += filtered_stats.removed_records;
             removed_stats.removed_file_size_bytes += filtered_stats.removed_file_size_bytes;
+            removed_stats
+                .filtered_entries
+                .extend(filtered_stats.filtered_entries);
             self.writer.append_ser(manifest)?;
         }
         Ok(removed_stats)

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -680,11 +680,14 @@ impl Operation {
                         branch.as_deref(),
                     )?;
 
+                let snapshot_id = generate_snapshot_id();
+
                 let mut filtered_stats = manifest_list_writer
                     .append_and_filter(
                         manifests_to_overwrite,
                         &files_to_overwrite,
                         object_store.clone(),
+                        snapshot_id,
                     )
                     .await?;
 
@@ -699,8 +702,6 @@ impl Operation {
                         .build()
                         .map_err(Error::from)
                 });
-
-                let snapshot_id = generate_snapshot_id();
 
                 let selected_manifest_location = manifest_list_writer
                     .selected_data_manifest()
@@ -744,6 +745,36 @@ impl Operation {
 
                 if let Some(selected_filter_stats) = selected_filter_stats {
                     filtered_stats.append(selected_filter_stats);
+                }
+
+                // Store separate manifest with filtered data files for compatability
+                if !filtered_stats.filtered_entries.is_empty() {
+                    let n_filtered_files = filtered_stats.filtered_entries.len();
+                    let filtered_iter = filtered_stats.filtered_entries.clone().into_iter().map(Ok);
+                    let n_filtered_splits =
+                        manifest_list_writer.n_splits(n_filtered_files, ManifestListContent::Data);
+
+                    if n_filtered_splits == 0 {
+                        manifest_list_writer
+                            .append(
+                                filtered_iter,
+                                snapshot_id,
+                                object_store.clone(),
+                                ManifestListContent::Data,
+                            )
+                            .await?;
+                    } else {
+                        manifest_list_writer
+                            .append_multiple_concurrently(
+                                filtered_iter,
+                                snapshot_id,
+                                n_filtered_splits,
+                                object_store.clone(),
+                                ManifestListContent::Data,
+                            )
+                            .await?
+                            .await?;
+                    };
                 }
 
                 let new_manifest_list_location = manifest_list_writer
@@ -1017,6 +1048,7 @@ pub(crate) fn update_snapshot_summary_by_filtered_stats(
     };
     subtract_from_summary("total-records", stats.removed_records, false);
     subtract_from_summary("deleted-data-files", stats.removed_data_files.into(), true);
+    subtract_from_summary("removed-files-size", stats.removed_file_size_bytes, true);
     subtract_from_summary("deleted-records", stats.removed_records, true);
     subtract_from_summary("total-data-files", stats.removed_data_files.into(), false);
     subtract_from_summary(


### PR DESCRIPTION
- for overwrite operation we need to save filtered data files for compatability with other iceberg engines since they take into account all deteled data files and stats within current snapshot 
**Spark** and**Snowflake** create additional manifest to track all deleted files for compatability
```Record 1:
  manifest_path: s3://...-m1.avro
  manifest_length: 7944
  partition_spec_id: 0
  content: 0
  sequence_number: 2
  min_sequence_number: 2
  added_snapshot_id: 8234522747398339109
  added_files_count: 1
  existing_files_count: 0
  deleted_files_count: 0
  added_rows_count: 6001215
  existing_rows_count: 0
  deleted_rows_count: 0
  partitions: []
  key_metadata: None

Record 2:
  manifest_path: s3://...-m0.avro
  manifest_length: 7942
  partition_spec_id: 0
  content: 0
  sequence_number: 2
  min_sequence_number: 2
  added_snapshot_id: 8234522747398339109
  added_files_count: 0
  existing_files_count: 0
  deleted_files_count: 1
  added_rows_count: 0
  existing_rows_count: 0
  deleted_rows_count: 6001215
  partitions: []
  key_metadata: None
```
- this mechanism can be also used in future to restore removed data