### PR TITLE
Make REST access delegation configurable

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/apis/configuration.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/configuration.rs
@@ -31,6 +31,12 @@ pub struct Configuration {
     pub user_agent: Option<String>,
     #[builder(default = "reqwest::Client::new()")]
     pub client: reqwest::Client,
+    /// Value for the optional `X-Iceberg-Access-Delegation` request header.
+    ///
+    /// For example, Snowflake Horizon can vend temporary storage credentials
+    /// when this is set to `vended-credentials`.
+    #[builder(setter(into, strip_option), default)]
+    pub access_delegation: Option<String>,
     #[builder(setter(into, strip_option), default)]
     pub basic_auth: Option<BasicAuth>,
     #[builder(setter(strip_option), default)]
@@ -48,6 +54,7 @@ impl std::fmt::Debug for Configuration {
         f.debug_struct("Configuration")
             .field("base_path", &self.base_path)
             .field("user_agent", &self.user_agent)
+            .field("access_delegation", &self.access_delegation)
             .field("basic_auth", &self.basic_auth)
             .field(
                 "oauth_access_token",
@@ -126,6 +133,7 @@ impl Default for Configuration {
             base_path: "https://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.1/rust".to_owned()),
             client: reqwest::Client::new(),
+            access_delegation: None,
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -348,7 +348,7 @@ impl Catalog for RestCatalog {
                         self.name.as_deref(),
                         &identifier.namespace().to_string(),
                         identifier.name(),
-                        Some("vended-credentials"),
+                        configuration.access_delegation.as_deref(),
                         None,
                     )
                     .await
@@ -393,7 +393,7 @@ impl Catalog for RestCatalog {
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             create_table,
-            Some("vended-credentials"),
+            configuration.access_delegation.as_deref(),
         )
         .map_err(Into::<Error>::into)
         .await?;
@@ -719,6 +719,7 @@ pub mod tests {
             base_path: url.to_owned(),
             user_agent: None,
             client: reqwest::Client::new(),
+            access_delegation: None,
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/datafusion_iceberg/tests/integration_trino.rs
+++ b/datafusion_iceberg/tests/integration_trino.rs
@@ -33,6 +33,7 @@ fn configuration(host: &str, port: u16) -> Configuration {
         base_path: format!("http://{host}:{port}"),
         user_agent: None,
         client: reqwest::Client::new(),
+        access_delegation: None,
         basic_auth: None,
         oauth_access_token: None,
         bearer_access_token: None,

--- a/iceberg-rust/src/file_format/parquet.rs
+++ b/iceberg-rust/src/file_format/parquet.rs
@@ -148,53 +148,30 @@ pub fn parquet_to_datafile(
                     match lower_bounds.entry(id) {
                         Entry::Occupied(mut entry) => {
                             let entry = entry.get_mut();
-                            match (&entry, &new) {
-                                (Value::Int(current), Value::Int(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
-                                }
+                            let replace = match (&*entry, &new) {
+                                (Value::Int(current), Value::Int(new_val)) => current > new_val,
                                 (Value::LongInt(current), Value::LongInt(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
+                                    current > new_val
                                 }
-                                (Value::Float(current), Value::Float(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
-                                }
+                                (Value::Float(current), Value::Float(new_val)) => current > new_val,
                                 (Value::Double(current), Value::Double(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
+                                    current > new_val
                                 }
                                 (Value::Decimal(current), Value::Decimal(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
+                                    current > new_val
                                 }
-                                (Value::Date(current), Value::Date(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
-                                }
-                                (Value::Time(current), Value::Time(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
-                                }
+                                (Value::Date(current), Value::Date(new_val)) => current > new_val,
+                                (Value::Time(current), Value::Time(new_val)) => current > new_val,
                                 (Value::Timestamp(current), Value::Timestamp(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
+                                    current > new_val
                                 }
                                 (Value::TimestampTZ(current), Value::TimestampTZ(new_val)) => {
-                                    if *current > *new_val {
-                                        *entry = new
-                                    }
+                                    current > new_val
                                 }
-                                _ => (),
+                                _ => false,
+                            };
+                            if replace {
+                                *entry = new;
                             }
                         }
                         Entry::Vacant(entry) => {
@@ -206,53 +183,30 @@ pub fn parquet_to_datafile(
                     match upper_bounds.entry(id) {
                         Entry::Occupied(mut entry) => {
                             let entry = entry.get_mut();
-                            match (&entry, &new) {
-                                (Value::Int(current), Value::Int(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
-                                }
+                            let replace = match (&*entry, &new) {
+                                (Value::Int(current), Value::Int(new_val)) => current < new_val,
                                 (Value::LongInt(current), Value::LongInt(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
+                                    current < new_val
                                 }
-                                (Value::Float(current), Value::Float(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
-                                }
+                                (Value::Float(current), Value::Float(new_val)) => current < new_val,
                                 (Value::Double(current), Value::Double(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
+                                    current < new_val
                                 }
                                 (Value::Decimal(current), Value::Decimal(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
+                                    current < new_val
                                 }
-                                (Value::Date(current), Value::Date(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
-                                }
-                                (Value::Time(current), Value::Time(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
-                                }
+                                (Value::Date(current), Value::Date(new_val)) => current < new_val,
+                                (Value::Time(current), Value::Time(new_val)) => current < new_val,
                                 (Value::Timestamp(current), Value::Timestamp(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
+                                    current < new_val
                                 }
                                 (Value::TimestampTZ(current), Value::TimestampTZ(new_val)) => {
-                                    if *current < *new_val {
-                                        *entry = new
-                                    }
+                                    current < new_val
                                 }
-                                _ => (),
+                                _ => false,
+                            };
+                            if replace {
+                                *entry = new;
                             }
                         }
                         Entry::Vacant(entry) => {

--- a/iceberg-rust/tests/empty_schema_manifest_test.rs
+++ b/iceberg-rust/tests/empty_schema_manifest_test.rs
@@ -72,7 +72,6 @@ use futures::stream;
 
 use iceberg_rust::arrow::write::write_parquet_partitioned;
 use iceberg_rust::catalog::Catalog;
-use iceberg_rust::error::Error;
 use iceberg_rust::object_store::{Bucket, ObjectStoreBuilder};
 use iceberg_rust::table::Table;
 use iceberg_rust_spec::spec::partition::PartitionSpec;
@@ -772,14 +771,16 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
     }
 
     // 10. Before corruption: verify we can read all datafiles
-    let mut pre_corruption_datafiles = table
+    let pre_corruption_datafiles = table
         .datafiles(&manifest_entries, None, (None, None))
         .await
         .expect("Failed to get datafiles before corruption");
 
     let mut pre_corruption_count = 0;
-    while let Some(Ok(_)) = pre_corruption_datafiles.next() {
-        pre_corruption_count += 1;
+    for datafile in pre_corruption_datafiles {
+        if datafile.is_ok() {
+            pre_corruption_count += 1;
+        }
     }
 
     println!("Datafiles before corruption: {}", pre_corruption_count);
@@ -851,10 +852,10 @@ async fn test_datafiles_with_zero_field_schema_manifest() {
     let result = table.datafiles(&manifest_entries, None, (None, None)).await;
 
     match result {
-        Ok(mut datafiles_iter) => {
+        Ok(datafiles_iter) => {
             // Count the datafiles
             let mut count = 0;
-            while let Some(result) = datafiles_iter.next() {
+            for result in datafiles_iter {
                 match result {
                     Ok(_) => count += 1,
                     Err(e) => {


### PR DESCRIPTION
## Summary
- adds `Configuration::access_delegation` for the REST catalog `X-Iceberg-Access-Delegation` header
- uses the configured value for `load_table` and `create_table` instead of hardcoding `vended-credentials`
- leaves access delegation disabled by default so callers can opt in explicitly
- fixes existing clippy warnings in the merged decimal-bounds code path so `-D warnings` passes on this branch

## Tests
- `cargo +stable check -p iceberg-rest-catalog`
- `cargo +stable test -p iceberg-rest-catalog --lib`
- `cargo +stable test -p iceberg-rust decimal`
- `cargo +stable clippy -p iceberg-rest-catalog --lib -- -D warnings`
- `cargo +stable clippy --all-targets --all-features -- -D warnings`
- `cargo +stable fmt --all -- --check`
