### PR TITLE
REST loadTable-first + snapshot-immutable manifest byte cache

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -325,60 +325,68 @@ impl Catalog for RestCatalog {
     /// Load a table.
     async fn load_tabular(self: Arc<Self>, identifier: &Identifier) -> Result<Tabular, Error> {
         let configuration = self.configuration.clone();
-        // Load View/Matview metadata, is loaded as tabular to enable both possibilities. Must not be table metadata
-        let tabular_metadata = catalog_api_api::load_view(
+        // Tables dominate every workload, so try loadTable first and fall
+        // back to loadView on 404 — the previous order paid a wasted
+        // loadView round-trip (always a 404) for every table load.
+        let table_response = catalog_api_api::load_table(
             &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
+            configuration.access_delegation.as_deref(),
+            None,
         )
-        .await
-        .map(|x| x.metadata);
-        match tabular_metadata {
-            Ok(TabularMetadata::View(view)) => Ok(Tabular::View(
-                View::new(identifier.clone(), self.clone(), view).await?,
-            )),
-            Ok(TabularMetadata::MaterializedView(matview)) => Ok(Tabular::MaterializedView(
-                MaterializedView::new(identifier.clone(), self.clone(), matview).await?,
-            )),
-            Err(apis::Error::ResponseError(content)) => {
-                if content.status == 404 {
-                    let response = catalog_api_api::load_table(
-                        &configuration,
-                        self.name.as_deref(),
-                        &identifier.namespace().to_string(),
-                        identifier.name(),
-                        configuration.access_delegation.as_deref(),
-                        None,
+        .await;
+        match table_response {
+            Ok(response) => {
+                let object_store = self.get_object_store(&response)?;
+
+                self.cache
+                    .write()
+                    .unwrap()
+                    .insert(identifier.clone(), object_store.clone());
+
+                let table_metadata = response.metadata;
+
+                Ok(Tabular::Table(
+                    Table::new(
+                        identifier.clone(),
+                        self.clone(),
+                        object_store,
+                        table_metadata,
                     )
-                    .await
-                    .map_err(|_| Error::CatalogNotFound)?;
-
-                    let object_store = self.get_object_store(&response)?;
-
-                    self.cache
-                        .write()
-                        .unwrap()
-                        .insert(identifier.clone(), object_store.clone());
-
-                    let table_metadata = response.metadata;
-
-                    Ok(Tabular::Table(
-                        Table::new(
-                            identifier.clone(),
-                            self.clone(),
-                            object_store,
-                            table_metadata,
-                        )
-                        .await?,
-                    ))
-                } else {
-                    Err(Into::<Error>::into(apis::Error::ResponseError(content)))
+                    .await?,
+                ))
+            }
+            Err(apis::Error::ResponseError(content)) if content.status == 404 => {
+                // Not a table: it may be a view or materialized view.
+                let view_response = catalog_api_api::load_view(
+                    &configuration,
+                    self.name.as_deref(),
+                    &identifier.namespace().to_string(),
+                    identifier.name(),
+                )
+                .await;
+                match view_response.map(|x| x.metadata) {
+                    Ok(TabularMetadata::View(view)) => Ok(Tabular::View(
+                        View::new(identifier.clone(), self.clone(), view).await?,
+                    )),
+                    Ok(TabularMetadata::MaterializedView(matview)) => {
+                        Ok(Tabular::MaterializedView(
+                            MaterializedView::new(identifier.clone(), self.clone(), matview)
+                                .await?,
+                        ))
+                    }
+                    Ok(TabularMetadata::Table(_)) => Err(Error::InvalidFormat(
+                        "Entity returned from load_view cannot be a table.".to_owned(),
+                    )),
+                    Err(apis::Error::ResponseError(view_content)) if view_content.status == 404 => {
+                        Err(Error::CatalogNotFound)
+                    }
+                    Err(err) => Err(Into::<Error>::into(err)),
                 }
             }
-            _ => Err(Error::InvalidFormat(
-                "Entity returned from load_view cannot be a table.".to_owned(),
-            )),
+            Err(err) => Err(Into::<Error>::into(err)),
         }
     }
     /// Register a table with the catalog if it doesn't exist.

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -134,14 +134,22 @@ pub(crate) async fn read_snapshot<'metadata>(
     table_metadata: &'metadata TableMetadata,
     object_store: Arc<dyn ObjectStore>,
 ) -> Result<impl Iterator<Item = Result<ManifestListEntry, Error>> + 'metadata, Error> {
-    let bytes: Cursor<Vec<u8>> = Cursor::new(
-        object_store
-            .get(&strip_prefix(snapshot.manifest_list()).into())
-            .await?
-            .bytes()
-            .await?
-            .into(),
-    );
+    // Manifest-list files are immutable by path; serve/populate the
+    // process-wide cache to skip the object-store round trip on re-scans.
+    let path = strip_prefix(snapshot.manifest_list());
+    let data = match crate::util::manifest_cache::get(&path) {
+        Some(bytes) => bytes,
+        None => {
+            let bytes = object_store
+                .get(&path.clone().into())
+                .await?
+                .bytes()
+                .await?;
+            crate::util::manifest_cache::put(&path, &bytes);
+            bytes
+        }
+    };
+    let bytes: Cursor<Vec<u8>> = Cursor::new(data.into());
     ManifestListReader::new(bytes, table_metadata)
 }
 

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -338,14 +338,23 @@ async fn datafiles(
             let object_store = object_store.clone();
             async move {
                 let manifest_path = &file.manifest_path;
-                let path: Path = util::strip_prefix(manifest_path).into();
-                let bytes = Cursor::new(Vec::from(
-                    object_store
-                        .get(&path)
-                        .and_then(|file| file.bytes())
-                        .instrument(tracing::trace_span!("iceberg_rust::get_manifest"))
-                        .await?,
-                ));
+                let stripped = util::strip_prefix(manifest_path);
+                // Manifest files are immutable by path; serve/populate the
+                // process-wide cache to skip per-scan object-store reads.
+                let data = match crate::util::manifest_cache::get(&stripped) {
+                    Some(bytes) => bytes,
+                    None => {
+                        let path: Path = stripped.clone().into();
+                        let bytes = object_store
+                            .get(&path)
+                            .and_then(|file| file.bytes())
+                            .instrument(tracing::trace_span!("iceberg_rust::get_manifest"))
+                            .await?;
+                        crate::util::manifest_cache::put(&stripped, &bytes);
+                        bytes
+                    }
+                };
+                let bytes = Cursor::new(Vec::from(data));
                 Ok::<_, Error>((bytes, manifest_path, file.sequence_number))
             }
         })

--- a/iceberg-rust/src/util/manifest_cache.rs
+++ b/iceberg-rust/src/util/manifest_cache.rs
@@ -1,0 +1,144 @@
+/*!
+Process-wide cache for immutable Iceberg manifest bytes.
+
+Manifest-list and manifest files are content-unique per snapshot — Iceberg
+never rewrites a file in place; new snapshots get new paths — so bytes cached
+by path never go stale and need no invalidation. Caching them removes the
+per-scan object-store round-trips (`manifest list GET + one GET per
+manifest`) that otherwise repeat on every scan of the same snapshot.
+
+The cache is byte-capped LRU. Capacity comes from `ICEBERG_MANIFEST_CACHE_MB`
+(read once per process; default 128 MiB; `0` disables caching entirely).
+Entries larger than the cap are never inserted.
+*/
+
+use bytes::Bytes;
+use lru::LruCache;
+use std::sync::{LazyLock, Mutex};
+
+const DEFAULT_CAP_MB: usize = 128;
+
+struct ByteCappedCache {
+    entries: LruCache<String, Bytes>,
+    total_bytes: usize,
+    cap_bytes: usize,
+}
+
+static CACHE: LazyLock<Option<Mutex<ByteCappedCache>>> = LazyLock::new(|| {
+    let cap_mb = std::env::var("ICEBERG_MANIFEST_CACHE_MB")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CAP_MB);
+    if cap_mb == 0 {
+        return None;
+    }
+    Some(Mutex::new(ByteCappedCache {
+        entries: LruCache::unbounded(),
+        total_bytes: 0,
+        cap_bytes: cap_mb.saturating_mul(1024 * 1024),
+    }))
+});
+
+/// Cached bytes for `path`, touching its LRU position.
+pub(crate) fn get(path: &str) -> Option<Bytes> {
+    let cache = CACHE.as_ref()?;
+    let mut guard = cache.lock().ok()?;
+    guard.entries.get(path).cloned()
+}
+
+/// Insert `bytes` under `path`, evicting least-recently-used entries until
+/// the byte cap holds. Oversized payloads are skipped.
+pub(crate) fn put(path: &str, bytes: &Bytes) {
+    let Some(cache) = CACHE.as_ref() else {
+        return;
+    };
+    let Ok(mut guard) = cache.lock() else {
+        return;
+    };
+    let len = bytes.len();
+    if len > guard.cap_bytes {
+        return;
+    }
+    if let Some(previous) = guard.entries.put(path.to_string(), bytes.clone()) {
+        guard.total_bytes = guard.total_bytes.saturating_sub(previous.len());
+    }
+    guard.total_bytes += len;
+    while guard.total_bytes > guard.cap_bytes {
+        match guard.entries.pop_lru() {
+            Some((_, evicted)) => {
+                guard.total_bytes = guard.total_bytes.saturating_sub(evicted.len());
+            }
+            None => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // The static cache reads its capacity from the environment once per
+    // process, so tests exercise the mechanics through a locally built
+    // instance of the same structure.
+    use super::*;
+
+    fn build(cap_bytes: usize) -> ByteCappedCache {
+        ByteCappedCache {
+            entries: LruCache::unbounded(),
+            total_bytes: 0,
+            cap_bytes,
+        }
+    }
+
+    fn put_in(cache: &mut ByteCappedCache, path: &str, bytes: &Bytes) {
+        let len = bytes.len();
+        if len > cache.cap_bytes {
+            return;
+        }
+        if let Some(previous) = cache.entries.put(path.to_string(), bytes.clone()) {
+            cache.total_bytes = cache.total_bytes.saturating_sub(previous.len());
+        }
+        cache.total_bytes += len;
+        while cache.total_bytes > cache.cap_bytes {
+            match cache.entries.pop_lru() {
+                Some((_, evicted)) => {
+                    cache.total_bytes = cache.total_bytes.saturating_sub(evicted.len());
+                }
+                None => break,
+            }
+        }
+    }
+
+    #[test]
+    fn hit_and_miss() {
+        let mut cache = build(1024);
+        put_in(&mut cache, "a", &Bytes::from(vec![1u8; 10]));
+        assert!(cache.entries.get("a").is_some());
+        assert!(cache.entries.get("b").is_none());
+    }
+
+    #[test]
+    fn byte_cap_evicts_lru() {
+        let mut cache = build(100);
+        put_in(&mut cache, "a", &Bytes::from(vec![0u8; 60]));
+        put_in(&mut cache, "b", &Bytes::from(vec![0u8; 60]));
+        // "a" evicted to fit "b".
+        assert!(cache.entries.get("a").is_none());
+        assert!(cache.entries.get("b").is_some());
+        assert!(cache.total_bytes <= 100);
+    }
+
+    #[test]
+    fn oversized_payload_skipped() {
+        let mut cache = build(50);
+        put_in(&mut cache, "big", &Bytes::from(vec![0u8; 51]));
+        assert!(cache.entries.get("big").is_none());
+        assert_eq!(cache.total_bytes, 0);
+    }
+
+    #[test]
+    fn replacing_entry_updates_accounting() {
+        let mut cache = build(100);
+        put_in(&mut cache, "a", &Bytes::from(vec![0u8; 40]));
+        put_in(&mut cache, "a", &Bytes::from(vec![0u8; 20]));
+        assert_eq!(cache.total_bytes, 20);
+    }
+}

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod manifest_cache;
 use std::cmp::Ordering;
 
 use iceberg_rust_spec::{


### PR DESCRIPTION
Two per-query cost cuts for REST-catalog workloads:

- load_tabular tried loadView first, paying a guaranteed-404 round trip for every table load. Tables dominate every workload: try loadTable first and fall back to loadView on 404. Non-404 errors now propagate from the first call instead of being masked as CatalogNotFound.

- Every scan re-read the manifest list and each manifest file from the object store. Those files are immutable by path (new snapshots get new paths), so a process-wide byte-capped LRU keyed by path is sound with no invalidation: ICEBERG_MANIFEST_CACHE_MB (read once; default 128, 0 disables). Wired into read_snapshot and Table::datafiles.