### PR TITLE
Review: key the manifest cache by original URI, not store-relative path

### DIFF
--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -136,16 +136,15 @@ pub(crate) async fn read_snapshot<'metadata>(
 ) -> Result<impl Iterator<Item = Result<ManifestListEntry, Error>> + 'metadata, Error> {
     // Manifest-list files are immutable by path; serve/populate the
     // process-wide cache to skip the object-store round trip on re-scans.
-    let path = strip_prefix(snapshot.manifest_list());
-    let data = match crate::util::manifest_cache::get(&path) {
+    // The cache key is the original URI (scheme + bucket + path): distinct
+    // stores can hold different bytes at the same store-relative path.
+    let uri = snapshot.manifest_list();
+    let data = match crate::util::manifest_cache::get(uri) {
         Some(bytes) => bytes,
         None => {
-            let bytes = object_store
-                .get(&path.clone().into())
-                .await?
-                .bytes()
-                .await?;
-            crate::util::manifest_cache::put(&path, &bytes);
+            let path = strip_prefix(uri);
+            let bytes = object_store.get(&path.into()).await?.bytes().await?;
+            crate::util::manifest_cache::put(uri, &bytes);
             bytes
         }
     };

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -338,19 +338,20 @@ async fn datafiles(
             let object_store = object_store.clone();
             async move {
                 let manifest_path = &file.manifest_path;
-                let stripped = util::strip_prefix(manifest_path);
                 // Manifest files are immutable by path; serve/populate the
                 // process-wide cache to skip per-scan object-store reads.
-                let data = match crate::util::manifest_cache::get(&stripped) {
+                // Keyed by the original URI so equal store-relative paths in
+                // different stores cannot alias each other.
+                let data = match crate::util::manifest_cache::get(manifest_path) {
                     Some(bytes) => bytes,
                     None => {
-                        let path: Path = stripped.clone().into();
+                        let path: Path = util::strip_prefix(manifest_path).into();
                         let bytes = object_store
                             .get(&path)
                             .and_then(|file| file.bytes())
                             .instrument(tracing::trace_span!("iceberg_rust::get_manifest"))
                             .await?;
-                        crate::util::manifest_cache::put(&stripped, &bytes);
+                        crate::util::manifest_cache::put(manifest_path, &bytes);
                         bytes
                     }
                 };

--- a/iceberg-rust/src/util/manifest_cache.rs
+++ b/iceberg-rust/src/util/manifest_cache.rs
@@ -7,6 +7,10 @@ by path never go stale and need no invalidation. Caching them removes the
 per-scan object-store round-trips (`manifest list GET + one GET per
 manifest`) that otherwise repeat on every scan of the same snapshot.
 
+Keys are the original file URIs (scheme + bucket + path), NOT store-relative
+paths: the cache is process-wide, and two object stores can hold different
+bytes at the same relative path (`s3://a/x` vs `s3://b/x`).
+
 The cache is byte-capped LRU. Capacity comes from `ICEBERG_MANIFEST_CACHE_MB`
 (read once per process; default 128 MiB; `0` disables caching entirely).
 Entries larger than the cap are never inserted.
@@ -105,6 +109,30 @@ mod tests {
                 None => break,
             }
         }
+    }
+
+    #[test]
+    fn uri_keys_do_not_collide_across_stores() {
+        // Same store-relative path under two buckets must stay two entries,
+        // and the stripped form must not be a key at all. Exercises the real
+        // process-wide cache (default cap, env unset in tests).
+        put(
+            "s3://bucket-a/db/tbl/metadata/x-m0.avro",
+            &Bytes::from_static(b"bytes-a"),
+        );
+        put(
+            "s3://bucket-b/db/tbl/metadata/x-m0.avro",
+            &Bytes::from_static(b"bytes-b"),
+        );
+        assert_eq!(
+            get("s3://bucket-a/db/tbl/metadata/x-m0.avro").as_deref(),
+            Some(b"bytes-a".as_slice())
+        );
+        assert_eq!(
+            get("s3://bucket-b/db/tbl/metadata/x-m0.avro").as_deref(),
+            Some(b"bytes-b".as_slice())
+        );
+        assert!(get("/db/tbl/metadata/x-m0.avro").is_none());
     }
 
     #[test]


### PR DESCRIPTION
The cache is process-wide; strip_prefix collapses s3://bucket-a/x and s3://bucket-b/x to the same /x, so two stores holding different bytes at equal relative paths could alias. Key by the full URI recorded in the snapshot/manifest metadata (available at both call sites) and add a two-store collision test.